### PR TITLE
WIP: preact alias, rollup configs + compat-lite

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "npm": "> 3"
   },
   "scripts": {
+    "build": "rollup -c --environment LIBRARY:react -o dist/index.js",
+    "build:preact": "rollup -c --environment LIBRARY:preact -o dist/preact/index.js",
     "start": "nps",
     "test": "nps test",
     "precommit": "lint-staged && opt --in pre-commit --exec \"npm start validate\""
@@ -23,16 +25,21 @@
   },
   "peerDependencies": {
     "react": ">=15",
-    "prop-types": ">=15"
+    "prop-types": ">=15",
+    "preact": ">=5"
   },
   "devDependencies": {
     "all-contributors-cli": "^4.3.0",
     "babel-cli": "^6.24.1",
     "babel-jest": "^20.0.3",
+    "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
+    "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-preset-env": "^1.6.0",
+    "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
+    "babel-preset-stage-0": "^6.24.1",
     "babel-register": "^6.24.1",
     "enzyme": "^2.9.1",
     "enzyme-to-json": "^1.5.1",
@@ -44,11 +51,18 @@
     "nps": "^5.4.0",
     "nps-utils": "^1.2.0",
     "opt-cli": "^1.5.1",
+    "preact": "^8.2.1",
     "prettier-eslint-cli": "^4.1.1",
     "prop-types": "^15.5.10",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
-    "react-test-renderer": "^15.6.1"
+    "react-test-renderer": "^15.6.1",
+    "rollup": "^0.45.2",
+    "rollup-plugin-alias": "^1.3.1",
+    "rollup-plugin-babel": "^2.7.1",
+    "rollup-plugin-commonjs": "^8.0.2",
+    "rollup-plugin-node-resolve": "^3.0.0",
+    "rollup-watch": "^4.3.1"
   },
   "lint-staged": {
     "*.js": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,74 @@
+import fs from 'fs'
+import alias from 'rollup-plugin-alias'
+import babel from 'rollup-plugin-babel'
+import pkg from './package.json'
+import commonjs from 'rollup-plugin-commonjs'
+import resolve from 'rollup-plugin-node-resolve'
+
+// import replace from 'rollup-plugin-replace'
+
+// * library & peerDeps stuff
+// build for both preact and react
+const library = process.env.LIBRARY === 'preact' ? 'preact' : 'react'
+
+// get peer dependencies
+const peerDeps = Object.keys(pkg.peerDependencies || {})
+
+// some peer dependancy checking
+// if React or Preact as an instance are not in peerDependencies throw this error
+if (library && peerDeps.indexOf(library) < 0) {
+  throw new Error('🚫 Please include your library as peer dependency')
+}
+
+// * Babel stuff Ideally ready from babelrc. this is a WIP will use .baberc later
+// const babelrc = JSON.parse(fs.readFileSync('.babelrc'))
+
+const preactBabelPlugins = [
+  'transform-class-properties',
+  ['transform-react-jsx', {pragma: 'h'}],
+  'external-helpers',
+]
+const reactBabelPlugins = [
+  'transform-class-properties',
+  ['transform-react-jsx'],
+  'external-helpers',
+]
+
+export default {
+  entry: 'src/index.js',
+  sourceMap: true,
+  dest: pkg.browser,
+  format: 'umd',
+  moduleName: pkg.name,
+  external: ['dom-scroll-into-view', 'react'],
+  plugins: [
+    alias(
+      library === 'preact' ?
+        {
+          react: `${__dirname}/src/compat/compat-lite.js`,
+          'prop-types': `${__dirname}/src/compat/prop-types.js`,
+        } :
+        {},
+    ),
+    resolve(),
+    commonjs({
+      include: ['node_modules/**'],
+      exclude: ['node_modules/process-es6/**'],
+      namedExports: {
+        'node_modules/react/react.js': [
+          'Children',
+          'Component',
+          'PropTypes',
+          'createElement',
+        ],
+        'node_modules/react-dom/index.js': ['render'],
+      },
+    }),
+    babel({
+      babelrc: false,
+      exclude: ['node_modules/**', '*.json'],
+      presets: [['es2015', {modules: false}], 'stage-0', 'react'],
+      plugins: library === 'preact' ? preactBabelPlugins : reactBabelPlugins,
+    }),
+  ],
+}

--- a/src/compat/compat-lite.js
+++ b/src/compat/compat-lite.js
@@ -1,0 +1,13 @@
+export * from 'preact'
+import preact from 'preact'
+
+export const Children = (preact.Children = {
+  only(children) {
+    return children && children[0]
+  },
+  count(children) {
+    return children ? children.length : 0
+  },
+})
+
+export default preact

--- a/src/compat/prop-types.js
+++ b/src/compat/prop-types.js
@@ -1,0 +1,11 @@
+function proptype() {}
+proptype.isRequired = proptype
+
+const PropTypes = {
+  element: proptype,
+  func: proptype,
+  shape: () => proptype,
+  instanceOf: () => proptype,
+}
+
+export default PropTypes


### PR DESCRIPTION
🚫 Not ready for merge.

I've only sent a PR from my private fork for reviews and opinions. 

Having a little issue with #4 when I rollup using the configs below, only reason I've posted here is I have not fiddled much recently with React tools and specs in depth. I'll be investigating that..

- [x] remove `dom-scroll-into-view`
- [x] update proptypes to compat `number, obj, any`
- [ ] add build default to build both preact & react one
- [ ] pass environment variable from Rollup to save a bunch of no-prod React stuff.