### PR TITLE
fix: wrong logic in constructor call

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -39,7 +39,7 @@ class Autocomplete extends Component {
       highlightedIndex: null,
       inputValue: '',
       isOpen: false,
-      selectedValue: this.props.defaultValue || this.props.multiple ? [] : '',
+      selectedValue: this.props.defaultValue || (this.props.multiple ? [] : ''),
     }
     this.root_handleClick = composeEventHandlers(
       this.props.onClick,


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Fix evaluation order (happens to me all the time ☺️)
<!-- Why are these changes necessary? -->
**Why**:
We were getting the wrong initial value
<!-- How were these changes implemented? -->
**How**:
Adding brackets around ternary since they have a higher operator precedence than `||`.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
