### PR TITLE
feat(stateProps): add the concept of state props

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,8 @@
   "rules": {
     "max-len": "off",
     "max-lines": "off",
-    "func-style": "off"
+    "func-style": "off",
+    "no-eq-null": "off",
+    "eqeqeq": "off"
   }
 }

--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ Available components and relevant props:
 
 ### Autocomplete
 
-This is the only component. It doesn't render anything itself, it just calls the child function and renders that. Wrap
-everything in this.
+This is the only component. It doesn't render anything itself, it just calls
+the child function and renders that. Wrap everything in this.
 
 #### getValue
 
@@ -163,6 +163,42 @@ A default `getA11yStatusMessage` function is provided that will check `resultCou
 > `function({selectedValue, previousValue})` | *required*
 
 Called when the user selects an item
+
+#### onStateChange
+
+> `function({highlightedIndex, inputValue, isOpen, selectedValue})` | not required, no useful default
+
+This function is called anytime the internal state changes. This can be useful
+if you're using downshift as a "controlled" component, where you manage some or
+all of the state (e.g. isOpen, selectedValue, highlightedIndex, etc) and then
+pass it as props, rather than letting downshift control all its state itself.
+
+#### highlightedIndex
+
+> `number` | **state prop** (read more below)
+
+The index that should be highlighted
+
+#### inputValue
+
+> `string` | **state prop** (read more below)
+
+The value the input should have
+
+#### isOpen
+
+> `boolean` | **state prop** (read more below)
+
+Whether the menu should be considered open or closed. Some aspects of the
+autocomplete component respond differently based on this value (for example, if
+`isOpen` is true when the user hits "Enter" on the input field, then the
+item at the `highlightedIndex` item is selected).
+
+#### `selectedValue`
+
+> `any`/`Array(any)` | **state prop** (read more below)
+
+The currently selected value.
 
 #### children
 
@@ -249,6 +285,17 @@ translations:
   'aria-label': translateWithId(isOpen ? 'close.menu' : 'open.menu'),
 })} />
 ```
+
+### State Props
+
+You can pass some props which normally the `downshift` will manage for you. If
+you pass these props, then they become "controlled" props. In this situation,
+`downshift` will no longer update them directly and will instead call your
+`onStateChange` handler and expect you to update them. This can be useful if
+you want to control the component externally (like selecting an item
+from another part of the UI).
+
+State Props are labeled above with **state prop**
 
 ## Examples
 

--- a/stories/config.js
+++ b/stories/config.js
@@ -5,6 +5,7 @@ import React from 'react'
 import {storiesOf} from '@storybook/react'
 
 import Basic from './examples/basic'
+import Controlled from './examples/controlled'
 import SemanticUI from './examples/semantic-ui'
 import Apollo from './examples/apollo'
 import Axios from './examples/axios'
@@ -17,6 +18,7 @@ function loadStories() {
 
   storiesOf('Examples', module)
     .add('basic', () => <Basic />)
+    .add('controlled', () => <Controlled />)
     .add('semantic-ui', () => <SemanticUI />)
     .add('apollo', () => <Apollo />)
     .add('axios', () => <Axios />)

--- a/stories/examples/basic.js
+++ b/stories/examples/basic.js
@@ -71,7 +71,7 @@ const Item = glamorous.div(
       borderColor: '#96c8da',
       boxShadow: '0 2px 3px 0 rgba(34,36,38,.15)',
     },
-  }),
+  })
 )
 
 const Input = glamorous.input({
@@ -130,7 +130,7 @@ function BasicAutocomplete({items, onChange}) {
                   })}
                 >
                     {item}
-                  </Item>),
+                  </Item>)
               )}
             </div>}
         </Root>)}

--- a/stories/examples/controlled.js
+++ b/stories/examples/controlled.js
@@ -1,0 +1,207 @@
+import React, {Component} from 'react'
+import glamorous, {Div} from 'glamorous'
+import matchSorter from 'match-sorter'
+import Autocomplete from '../../src'
+
+const Input = glamorous.input({
+  fontSize: 14,
+  wordWrap: 'break-word',
+  lineHeight: '1em',
+  outline: 0,
+  whiteSpace: 'normal',
+  minHeight: '2em',
+  background: '#fff',
+  display: 'inline-block',
+  padding: '.5em 2em .5em 1em',
+  color: 'rgba(0,0,0,.87)',
+  boxShadow: 'none',
+  border: '1px solid rgba(34,36,38,.15)',
+  transition: 'box-shadow .1s ease,width .1s ease',
+  margin: 0,
+  marginBottom: '-2px',
+  '&:hover, &focus': {
+    borderColor: 'rgba(34,36,38,.35)',
+    boxShadow: 'none',
+  },
+})
+
+class Examples extends Component {
+  state = {
+    selectedColor: '',
+    inputValue: '',
+    isOpen: false,
+  }
+  items = ['Black', 'Red', 'Green', 'Blue', 'Orange', 'Purple']
+
+  changeHandler = changes => {
+    let {
+      selectedValue = this.state.selectedColor,
+      isOpen = this.state.isOpen,
+      inputValue = this.state.inputValue,
+      type,
+    } = changes
+    isOpen =
+      type === Autocomplete.stateChangeTypes.mouseUp
+        ? this.state.isOpen
+        : isOpen
+    this.setState({
+      selectedColor: selectedValue,
+      isOpen,
+      inputValue,
+    })
+  }
+
+  handleInputChange = event => {
+    const {value} = event.target
+    const nextState = {inputValue: value}
+    if (this.items.includes(value)) {
+      nextState.selectedColor = value
+    }
+    this.setState(nextState)
+  }
+
+  clearSelection = () => {
+    this.setState({inputValue: '', selectedColor: ''})
+  }
+
+  toggleMenu = () => {
+    this.setState(({isOpen}) => ({isOpen: !isOpen}))
+  }
+
+  render() {
+    return (
+      <div>
+        <Div
+          css={{
+            margin: '50px auto',
+            maxWidth: 600,
+            textAlign: 'center',
+          }}
+        >
+          <h2>Controlled Autocomplete</h2>
+          <p>
+            {`
+              In this example, we're passing controlling props directly to the downshift
+              component. This allows us to control which item is selected from the outside.
+              In our example we're passing the selectedValue, isOpen, and inputValue and we're
+              able to control a bunch of stuff from the outside
+            `}
+          </p>
+          <Div marginBottom={30}>
+            <div>
+              <Input
+                placeholder="Set the value ourselves here"
+                onChange={this.handleInputChange}
+                value={this.state.inputValue}
+                css={{width: 300, maxWidth: '100%', marginBottom: 10}}
+              />
+            </div>
+            <div>
+              <button onClick={this.clearSelection}>clear selection</button>
+            </div>
+            <div>
+              <button onClick={this.toggleMenu}>
+                toggle menu {this.state.isOpen ? 'closed' : 'open'}
+              </button>
+            </div>
+          </Div>
+          <Div display="flex" justifyContent="center">
+            <span
+              style={{
+                height: '2em',
+                width: '2em',
+                padding: '.3em',
+                borderRadius: '5px',
+                marginRight: '.5em',
+                backgroundColor: this.state.selectedColor
+                  ? this.state.selectedColor
+                  : 'transparent',
+              }}
+            />
+            <ControlledAutocomplete
+              selectedValue={this.state.selectedColor}
+              items={this.items}
+              isOpen={this.state.isOpen}
+              inputValue={this.state.inputValue}
+              onChange={this.changeHandler}
+              onStateChange={this.changeHandler}
+              onInputChange={this.handleInputChange}
+            />
+          </Div>
+        </Div>
+      </div>
+    )
+  }
+}
+
+const Item = glamorous.div(
+  {
+    cursor: 'pointer',
+    display: 'block',
+    border: 'none',
+    height: 'auto',
+    textAlign: 'left',
+    borderTop: 'none',
+    lineHeight: '1em',
+    color: 'rgba(0,0,0,.87)',
+    fontSize: '1rem',
+    textTransform: 'none',
+    fontWeight: '400',
+    boxShadow: 'none',
+    padding: '.8rem 1.1rem',
+    boxSizing: 'border-box',
+    whiteSpace: 'normal',
+    wordWrap: 'normal',
+  },
+  ({isActive, isSelected}) => ({
+    backgroundColor: isActive ? 'lightgrey' : 'white',
+    fontWeight: isSelected ? 'bold' : 'normal',
+    '&:hover, &:focus': {
+      borderColor: '#96c8da',
+      boxShadow: '0 2px 3px 0 rgba(34,36,38,.15)',
+    },
+  }),
+)
+
+function ControlledAutocomplete({onInputChange, items, ...rest}) {
+  return (
+    <Autocomplete {...rest}>
+      {({
+        getInputProps,
+        getItemProps,
+        getRootProps,
+        highlightedIndex,
+        inputValue,
+        isOpen,
+        selectedValue,
+      }) =>
+        (<div>
+          <Input
+            {...getInputProps({
+              placeholder: 'Favorite color ?',
+              onChange: onInputChange,
+            })}
+          />
+          {isOpen &&
+            <div style={{border: '1px solid rgba(34,36,38,.15)'}}>
+              {(inputValue
+                ? matchSorter(items, inputValue)
+                : items).map((item, index) =>
+                  (<Item
+                    key={item}
+                    {...getItemProps({
+                    value: item,
+                    index,
+                    isActive: highlightedIndex === index,
+                    isSelected: selectedValue === item,
+                  })}
+                >
+                    {item}
+                  </Item>),
+              )}
+            </div>}
+        </div>)}
+    </Autocomplete>
+  )
+}
+export default Examples


### PR DESCRIPTION
This adds the concept of `state props` to enable a totally controlled component experience. It's actually quite awesome if I say so myself. 🕶

Feedback welcome!

Closes #80

**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [ ] Tests N/A (we don't have tests yet. Still solidifying the API)
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

cc @jgoux, this is what you're looking for I think :smile: I'd really appreciate a review!