### PR TITLE
Remove references to `value` (except `inputValue`) & other improvement

### DIFF
--- a/stories/examples/apollo.js
+++ b/stories/examples/apollo.js
@@ -36,7 +36,7 @@ function ApolloAutocomplete() {
         inputValue,
         getInputProps,
         getItemProps,
-        selectedValue,
+        selectedItem,
         highlightedIndex,
         isOpen,
       }) =>
@@ -47,7 +47,7 @@ function ApolloAutocomplete() {
               {...{
                   inputValue,
                   getItemProps,
-                  selectedValue,
+                  selectedItem,
                   highlightedIndex,
                   isOpen,
                 }}
@@ -60,7 +60,7 @@ function ApolloAutocomplete() {
 
 function ApolloAutocompleteMenu({
   data: {allColors = [], loading} = {},
-  selectedValue,
+  selectedItem,
   highlightedIndex,
   isOpen,
   getItemProps,
@@ -77,11 +77,11 @@ function ApolloAutocompleteMenu({
         (<div
           key={item}
           {...getItemProps({
-            value: item,
+            item,
             index,
             style: {
               backgroundColor: highlightedIndex === index ? 'gray' : 'white',
-              fontWeight: selectedValue === item ? 'bold' : 'normal',
+              fontWeight: selectedItem === item ? 'bold' : 'normal',
             },
           })}
         >

--- a/stories/examples/axios.js
+++ b/stories/examples/axios.js
@@ -25,7 +25,7 @@ class AxiosAutocomplete extends Component {
     return (
       <Autocomplete>
         {({
-          selectedValue,
+          selectedItem,
           getInputProps,
           getItemProps,
           highlightedIndex,
@@ -60,13 +60,12 @@ class AxiosAutocomplete extends Component {
                     (<div
                       key={index}
                       {...getItemProps({
-                        value: item,
+                        item,
                         index,
                         style: {
                           backgroundColor:
                             highlightedIndex === index ? 'gray' : 'white',
-                          fontWeight:
-                            selectedValue === item ? 'bold' : 'normal',
+                          fontWeight: selectedItem === item ? 'bold' : 'normal',
                         },
                       })}
                     >

--- a/stories/examples/basic.js
+++ b/stories/examples/basic.js
@@ -8,8 +8,8 @@ class Examples extends Component {
     selectedColor: '',
   }
 
-  changeHandler = ({selectedValue}) => {
-    this.setState({selectedColor: selectedValue})
+  changeHandler = ({selectedItem}) => {
+    this.setState({selectedColor: selectedItem})
   }
 
   render() {
@@ -114,7 +114,7 @@ function BasicAutocomplete({items, onChange}) {
         highlightedIndex,
         inputValue,
         isOpen,
-        selectedValue,
+        selectedItem,
       }) =>
         (<Root {...getRootProps({refKey: 'innerRef'})}>
           <Label {...getLabelProps()}>What is your favorite color?</Label>
@@ -127,10 +127,10 @@ function BasicAutocomplete({items, onChange}) {
                   (<Item
                     key={item}
                     {...getItemProps({
-                    value: item,
+                    item,
                     index,
                     isActive: highlightedIndex === index,
-                    isSelected: selectedValue === item,
+                    isSelected: selectedItem === item,
                   })}
                 >
                     {item}

--- a/stories/examples/controlled.js
+++ b/stories/examples/controlled.js
@@ -35,14 +35,14 @@ class Examples extends Component {
 
   changeHandler = changes => {
     this.setState({
-      selectedColor: changes.selectedValue,
+      selectedColor: changes.selectedItem,
       isOpen: false,
     })
   }
 
   stateChangeHandler = changes => {
     let {
-      selectedValue = this.state.selectedColor,
+      selectedItem = this.state.selectedColor,
       isOpen = this.state.isOpen,
       inputValue = this.state.inputValue,
       type,
@@ -52,7 +52,7 @@ class Examples extends Component {
         ? this.state.isOpen
         : isOpen
     this.setState({
-      selectedColor: selectedValue,
+      selectedColor: selectedItem,
       isOpen,
       inputValue,
     })
@@ -90,7 +90,7 @@ class Examples extends Component {
             {`
               In this example, we're passing controlling props directly to the downshift
               component. This allows us to control which item is selected from the outside.
-              In our example we're passing the selectedValue, isOpen, and inputValue and we're
+              In our example we're passing the selectedItem, isOpen, and inputValue and we're
               able to control a bunch of stuff from the outside
             `}
           </p>
@@ -126,7 +126,7 @@ class Examples extends Component {
               }}
             />
             <ControlledAutocomplete
-              selectedValue={this.state.selectedColor}
+              selectedItem={this.state.selectedColor}
               items={this.items}
               isOpen={this.state.isOpen}
               inputValue={this.state.inputValue}
@@ -180,7 +180,7 @@ function ControlledAutocomplete({onInputChange, items, ...rest}) {
         highlightedIndex,
         inputValue,
         isOpen,
-        selectedValue,
+        selectedItem,
       }) =>
         (<div>
           <Input
@@ -197,10 +197,10 @@ function ControlledAutocomplete({onInputChange, items, ...rest}) {
                   (<Item
                     key={item}
                     {...getItemProps({
-                    value: item,
+                    item,
                     index,
                     isActive: highlightedIndex === index,
-                    isSelected: selectedValue === item,
+                    isSelected: selectedItem === item,
                   })}
                 >
                     {item}

--- a/stories/examples/react-instantsearch.js
+++ b/stories/examples/react-instantsearch.js
@@ -14,7 +14,7 @@ function RawAutoComplete({refine, hits}) {
       {({
         getInputProps,
         getItemProps,
-        selectedValue,
+        selectedItem,
         highlightedIndex,
         isOpen,
       }) =>
@@ -32,12 +32,12 @@ function RawAutoComplete({refine, hits}) {
                 (<div
                   key={item.objectID}
                   {...getItemProps({
-                    value: item,
+                    item,
                     index,
                     style: {
                       backgroundColor:
                         highlightedIndex === index ? 'gray' : 'white',
-                      fontWeight: selectedValue === item ? 'bold' : 'normal',
+                      fontWeight: selectedItem === item ? 'bold' : 'normal',
                     },
                   })}
                 >

--- a/stories/examples/react-popper.js
+++ b/stories/examples/react-popper.js
@@ -46,15 +46,15 @@ class ReactPopperAutocomplete extends PureComponent {
       >
         <Manager>
           <Autocomplete
-            onChange={({selectedValue}) =>
-              this.setState({selected: selectedValue})}
+            onChange={({selectedItem}) =>
+              this.setState({selected: selectedItem})}
             style={{display: 'inline-block', position: 'relative'}}
           >
             {({
               getInputProps,
               getItemProps,
               inputValue,
-              selectedValue,
+              selectedItem,
               highlightedIndex,
               isOpen,
             }) =>
@@ -78,7 +78,7 @@ class ReactPopperAutocomplete extends PureComponent {
                           (<div
                             {...getItemProps({
                               index,
-                              value: item,
+                              item,
                             })}
                             key={item}
                             style={{
@@ -87,7 +87,7 @@ class ReactPopperAutocomplete extends PureComponent {
                                   ? 'rgba(0, 0, 0, .2)'
                                   : 'transparent',
                               fontWeight:
-                                selectedValue === item ? 'bold' : 'normal',
+                                selectedItem === item ? 'bold' : 'normal',
                             }}
                           >
                             {item}

--- a/stories/examples/semantic-ui.js
+++ b/stories/examples/semantic-ui.js
@@ -135,7 +135,7 @@ function SemanticUIAutocomplete() {
       getValue={i => i.name}
       // defaultHighlightedIndex={0}
       // defaultSelectedItem={items[20]}
-      onChange={({selectedValue}) => alert(selectedValue.name)}
+      onChange={({selectedItem}) => alert(selectedItem.name)}
       style={{
         width: '250px',
       }}
@@ -147,7 +147,7 @@ function SemanticUIAutocomplete() {
         clearSelection,
         rootRef,
         inputValue,
-        selectedValue,
+        selectedItem,
         getButtonProps,
         getInputProps,
         getItemProps,
@@ -160,7 +160,7 @@ function SemanticUIAutocomplete() {
                 placeholder: 'Enter some info',
               })}
             />
-            {selectedValue
+            {selectedItem
               ? <ControlButton
                 css={{paddingTop: 4}}
                 onClick={clearSelection}
@@ -180,10 +180,10 @@ function SemanticUIAutocomplete() {
                   (<Item
                     key={item.code}
                     {...getItemProps({
-                    value: item,
+                    item,
                     index,
                     isActive: highlightedIndex === index,
-                    isSelected: selectedValue === item,
+                    isSelected: selectedItem === item,
                   })}
                 >
                     {item.name}


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: This has a few breaking changes to the API. The biggest 2 are `getInputProps` now accepts `item` rather than `value` and `selectedValue` is now `selectedItem`.

<!-- Why are these changes necessary? -->
**Why**: Really simplifies things. Closes #93, Closes #90, Closes #101, Closes #94

<!-- How were these changes implemented? -->
**How**: Coding... I guess. Watch the livestream later :wink:

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A

<!-- feel free to add additional comments -->
