### PR TITLE
fix(getItemProps): clicking anywhere in the item selects the item

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,13 +192,13 @@ properties:
 
 #### onChange
 
-> `function({selectedItem, previousItem})` | *required*
+> `function({selectedItem, previousItem})` | optional, no useful default
 
 Called when the user selects an item
 
 #### onStateChange
 
-> `function({highlightedIndex, inputValue, isOpen, selectedItem})` | not required, no useful default
+> `function({highlightedIndex, inputValue, isOpen, selectedItem})` | optional, no useful default
 
 This function is called anytime the internal state changes. This can be useful
 if you're using downshift as a "controlled" component, where you manage some or

--- a/src/__tests__/.eslintrc
+++ b/src/__tests__/.eslintrc
@@ -1,5 +1,6 @@
 {
   "rules": {
-    "react/prop-types": "off"
+    "react/prop-types": "off",
+    "react/display-name": "off"
   }
 }

--- a/src/__tests__/downshift.get-item-props.js
+++ b/src/__tests__/downshift.get-item-props.js
@@ -1,0 +1,65 @@
+import React from 'react'
+import {mount} from 'enzyme'
+import Downshift from '../'
+
+const colors = [
+  'Red',
+  'Green',
+  'Blue',
+  'Orange',
+  'Purple',
+  'Pink',
+  'Palevioletred',
+  'Rebeccapurple',
+  'Navy Blue',
+]
+
+test('clicking on a DOM node within an item selects that item', () => {
+  // inspiration: https://github.com/paypal/downshift/issues/113
+  const items = ['Chess', 'Dominion', 'Checkers']
+  const {Component, childSpy} = setup({
+    items,
+    itemMap(getItemProps, item, index) {
+      return (
+        <div {...getItemProps({item, index, key: index})}>
+          <button>
+            {item}
+          </button>
+        </div>
+      )
+    },
+  })
+  const wrapper = mount(<Component />)
+  const firstButton = wrapper.find('button').first()
+  childSpy.mockClear()
+  firstButton.simulate('click')
+  expect(childSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      selectedItem: items[0],
+    }),
+  )
+})
+
+function setup(
+  {
+    items = colors,
+    itemMap = (getItemProps, item, index) =>
+      (<div key={item} {...getItemProps({item, index})}>
+        {item}
+      </div>),
+  } = {},
+) {
+  const childSpy = jest.fn(({getItemProps}) =>
+    (<div>
+      {items.map((item, index) => itemMap(getItemProps, item, index))}
+    </div>),
+  )
+  function BasicDownshift(props) {
+    return (
+      <Downshift isOpen={true} onChange={() => {}} {...props}>
+        {childSpy}
+      </Downshift>
+    )
+  }
+  return {Component: BasicDownshift, childSpy}
+}

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types'
 import setA11yStatus from './set-a11y-status'
 import {
   cbToCb,
+  findParent,
   composeEventHandlers,
   debounce,
   scrollIntoView,
@@ -45,6 +46,7 @@ class Downshift extends Component {
     getA11yStatusMessage,
     itemToString: i => (i == null ? '' : String(i)),
     onStateChange: () => {},
+    onChange: () => {},
   }
 
   // this is an experimental feature
@@ -328,9 +330,18 @@ class Downshift extends Component {
     if (!target) {
       return
     }
-    const index = this.getItemIndexFromId(target.getAttribute('id'))
-    if (isNumber(index)) {
-      this.selectItemAtIndex(index)
+    const itemParent = findParent(
+      node => {
+        const index = this.getItemIndexFromId(node.getAttribute('id'))
+        return isNumber(index)
+      },
+      target,
+      this._rootNode,
+    )
+    if (itemParent) {
+      this.selectItemAtIndex(
+        this.getItemIndexFromId(itemParent.getAttribute('id')),
+      )
     }
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,24 +13,28 @@ function cbToCb(cb) {
 }
 function noop() {}
 
-/**
- * Get the closest element that scrolls
- * @param {HTMLElement} node - the child element to start searching for scroll parent at
- * @param {HTMLElement} rootNode - the root element of the component
- * @return {HTMLElement} the closest parentNode that scrolls
- */
-function getClosestScrollParent(node, rootNode) {
-  if (node !== null && node !== rootNode) {
-    const isScrollable = node.scrollHeight > node.clientHeight
-    if (isScrollable) {
+function findParent(finder, node, rootNode) {
+  if (node !== null && node !== rootNode.parentNode) {
+    if (finder(node)) {
       return node
     } else {
-      return getClosestScrollParent(node.parentNode)
+      return findParent(finder, node.parentNode, rootNode)
     }
   } else {
     return null
   }
 }
+
+/**
+* Get the closest element that scrolls
+* @param {HTMLElement} node - the child element to start searching for scroll parent at
+* @param {HTMLElement} rootNode - the root element of the component
+* @return {HTMLElement} the closest parentNode that scrolls
+*/
+const getClosestScrollParent = findParent.bind(
+  null,
+  node => node.scrollHeight > node.clientHeight,
+)
 
 /**
  * Scroll node into view if necessary
@@ -172,6 +176,7 @@ function getA11yStatusMessage({
 
 export {
   cbToCb,
+  findParent,
   composeEventHandlers,
   debounce,
   scrollIntoView,

--- a/stories/examples/basic.js
+++ b/stories/examples/basic.js
@@ -120,7 +120,13 @@ function BasicAutocomplete({items, onChange}) {
           <Label {...getLabelProps()}>What is your favorite color?</Label>
           <Input {...getInputProps({placeholder: 'Enter color here'})} />
           {isOpen &&
-            <div style={{border: '1px solid rgba(34,36,38,.15)'}}>
+            <div
+              style={{
+                border: '1px solid rgba(34,36,38,.15)',
+                maxHeight: 100,
+                overflowY: 'scroll',
+              }}
+            >
               {(inputValue
                 ? matchSorter(items, inputValue)
                 : items).map((item, index) =>


### PR DESCRIPTION
Closes #113

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: This looks up the tree to find the closest parent with the item id.

<!-- Why are these changes necessary? -->
**Why**: This fixes an issue where if you have items with a nested structure the item would not be selected because the `target` did not have the `id` on it.

<!-- How were these changes implemented? -->
**How**: Refactor `getClosestScrollParent` into a generic `findParent` function and use that. This actually also fixed a bug in `getClosestScrollParent` where the `rootNode` was not passed recursively and the search would stop prematurely.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A

<!-- feel free to add additional comments -->
