### PR TITLE
fix(onStateChange): only call the handler when state actually changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,12 +198,20 @@ Called when the user selects an item
 
 #### onStateChange
 
-> `function({highlightedIndex, inputValue, isOpen, selectedItem})` | optional, no useful default
+> `function(changes, allState)` | optional, no useful default
 
 This function is called anytime the internal state changes. This can be useful
 if you're using downshift as a "controlled" component, where you manage some or
 all of the state (e.g. isOpen, selectedItem, highlightedIndex, etc) and then
 pass it as props, rather than letting downshift control all its state itself.
+The parameters both take the shape of internal state
+(`{highlightedIndex: number, inputValue: string, isOpen: boolean, selectedItem: any}`)
+but differ slightly.
+
+- `changes`: These are the properties that actually have changed since the last
+  state change
+- `allState`: This is the full state object of all the state in your `downshift`
+  component.
 
 #### itemCount
 

--- a/src/__tests__/downshift.misc.js
+++ b/src/__tests__/downshift.misc.js
@@ -45,14 +45,38 @@ test('clearSelection with an input node focuses the input node', () => {
   expect(document.activeElement).toBe(input.getDOMNode())
 })
 
-function setup({children = () => <div />} = {}) {
+test('onStateChange called with changes and all the state', () => {
+  const handleStateChange = jest.fn()
+  const controlledState = {
+    inputValue: '',
+    selectedItem: null,
+  }
+  const {selectItem} = setup({
+    ...controlledState,
+    onStateChange: handleStateChange,
+  })
+  const itemToSelect = 'foo'
+  selectItem(itemToSelect)
+  const changes = {
+    selectedItem: itemToSelect,
+    inputValue: itemToSelect,
+  }
+  const allState = {
+    ...controlledState,
+    isOpen: false,
+    highlightedIndex: null,
+  }
+  expect(handleStateChange).toHaveBeenLastCalledWith(changes, allState)
+})
+
+function setup({children = () => <div />, ...props} = {}) {
   let renderArg
   const childSpy = jest.fn(controllerArg => {
     renderArg = controllerArg
     return children(controllerArg)
   })
   const wrapper = mount(
-    <Downshift>
+    <Downshift {...props}>
       {childSpy}
     </Downshift>,
   )

--- a/src/utils.js
+++ b/src/utils.js
@@ -132,21 +132,6 @@ function isNumber(thing) {
   return thing === thing && typeof thing === 'number'
 }
 
-/**
- * Determines whether the two given objects have shallow
- * equality with respect to the keys given in obj2.
- * In other words, every value in obj2 is equal to the
- * value of the same key in obj1.
- * @param {Object} obj1 the first
- * @param {Object} obj2 the second
- * @return {Boolean} whether they are shallowly equal
- */
-function containsSubset(obj1, obj2) {
-  return Object.keys(obj2).every(key => {
-    return obj1[key] === obj2[key]
-  })
-}
-
 // eslint-disable-next-line complexity
 function getA11yStatusMessage({
   isOpen,
@@ -183,6 +168,5 @@ export {
   generateId,
   firstDefined,
   isNumber,
-  containsSubset,
   getA11yStatusMessage,
 }


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: fix(onStateChange): only call the handler when state actually changes

Also adds a second parameter that has all the state

<!-- Why are these changes necessary? -->
**Why**: Closes #123

<!-- How were these changes implemented? -->
**How**: Refactoring `internalSetState`

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A

<!-- feel free to add additional comments -->
