### PR TITLE
fix(inputValue): initilize the inputValue correctly

### DIFF
--- a/src/__tests__/downshift.lifecycle.js
+++ b/src/__tests__/downshift.lifecycle.js
@@ -69,6 +69,20 @@ test('props update causes the a11y status to be updated', () => {
   expect(setA11yStatus).toHaveBeenCalledTimes(1)
 })
 
+test('inputValue initializes properly if the selectedItem is controlled and set', () => {
+  const childSpy = jest.fn(() => null)
+  mount(
+    <Downshift selectedItem={'foo'}>
+      {childSpy}
+    </Downshift>,
+  )
+  expect(childSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      inputValue: 'foo',
+    }),
+  )
+})
+
 test('props update of selectedItem will update the inputValue state', () => {
   const childSpy = jest.fn(() => null)
   const wrapper = mount(

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -58,12 +58,16 @@ class Downshift extends Component {
   constructor(...args) {
     super(...args)
     this.id = generateId('downshift')
-    this.state = {
+    const state = this.getState({
       highlightedIndex: this.props.defaultHighlightedIndex,
-      inputValue: this.props.defaultInputValue,
       isOpen: this.props.defaultIsOpen,
+      inputValue: this.props.defaultInputValue,
       selectedItem: this.props.defaultSelectedItem,
+    })
+    if (state.selectedItem) {
+      state.inputValue = this.props.itemToString(state.selectedItem)
     }
+    this.state = state
     this.root_handleClick = composeEventHandlers(
       this.props.onClick,
       this.root_handleClick,
@@ -91,7 +95,7 @@ class Downshift extends Component {
    */
   getState(stateToMerge = this.state) {
     return Object.keys(stateToMerge).reduce((state, key) => {
-      state[key] = this.isStateProp(key) ? this.props[key] : this.state[key]
+      state[key] = this.isStateProp(key) ? this.props[key] : stateToMerge[key]
       return state
     }, {})
   }


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: This initializes the `inputValue` based on the `selectedItem`

<!-- Why are these changes necessary? -->
**Why**: So if `selectedItem` is given as a prop, the `inputValue` is set based on `this.props.itemToString`. Closes #119

<!-- How were these changes implemented? -->
**How**: Updated the constructor and fixed a bug in `getState`.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A

<!-- feel free to add additional comments -->
