### PR TITLE
feat(onChange): remove previousItem from onChange callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ function App() {
   return (
     <BasicAutocomplete
       items={['apple', 'orange', 'carrot']}
-      onChange={({selectedItem}) => console.log(selectedItem)}
+      onChange={selectedItem => console.log(selectedItem)}
     />
   )
 }
@@ -189,13 +189,15 @@ properties:
 
 ### onChange
 
-> `function({selectedItem, previousItem})` | optional, no useful default
+> `function(selectedItem: any, allState: object)` | optional, no useful default
 
-Called when the user selects an item
+Called when the user selects an item. Called with the item that was selected
+and the new state of `downshift`. (see `onStateChange` for more info on
+`allState`).
 
 ### onStateChange
 
-> `function(changes, allState)` | optional, no useful default
+> `function(changes: object, allState: object)` | optional, no useful default
 
 This function is called anytime the internal state changes. This can be useful
 if you're using downshift as a "controlled" component, where you manage some or

--- a/src/__tests__/downshift.get-input-props.js
+++ b/src/__tests__/downshift.get-input-props.js
@@ -121,22 +121,22 @@ test('enter on an input with an open menu does nothing without a highlightedInde
 test('enter on an input with an open menu and a highlightedIndex selects that item', () => {
   const {Component, childSpy} = setup()
   const onChange = jest.fn()
-  const wrapper = mount(<Component isOpen={true} onChange={onChange} />)
+  const isOpen = true
+  const wrapper = mount(<Component isOpen={isOpen} onChange={onChange} />)
   const input = wrapper.find(sel('input'))
   // ↓
   input.simulate('keydown', {key: 'ArrowDown'})
   // ENTER
   input.simulate('keydown', {key: 'Enter'})
   expect(onChange).toHaveBeenCalledTimes(1)
-  expect(onChange).toHaveBeenCalledWith({
+  const newState = expect.objectContaining({
     selectedItem: colors[0],
-    previousItem: null,
+    isOpen,
+    highlightedIndex: null,
+    inputValue: colors[0],
   })
-  expect(childSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({
-      selectedItem: colors[0],
-    }),
-  )
+  expect(onChange).toHaveBeenCalledWith(colors[0], newState)
+  expect(childSpy).toHaveBeenLastCalledWith(newState)
 })
 
 test('escape on an input without a selection should reset downshift and close the menu', () => {

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -211,7 +211,7 @@ class Downshift extends Component {
   // In addition, we'll call this.props.onChange if the
   // selectedItem is changed.
   internalSetState(stateToSet, cb) {
-    const onChangeArg = {}
+    let onChangeArg
     const onStateChangeArg = {}
     return this.setState(
       state => {
@@ -226,8 +226,7 @@ class Downshift extends Component {
         // and we're trying to update that state. OR if the selection has changed and we're
         // trying to update the selection
         if (stateToSet.hasOwnProperty('selectedItem')) {
-          onChangeArg.selectedItem = stateToSet.selectedItem
-          onChangeArg.previousItem = state.selectedItem
+          onChangeArg = stateToSet.selectedItem
         }
         Object.keys(stateToSet).forEach(key => {
           // the type is useful for the onStateChangeArg
@@ -261,8 +260,8 @@ class Downshift extends Component {
         if (Object.keys(onStateChangeArg).length) {
           this.props.onStateChange(onStateChangeArg, this.getState())
         }
-        if (Object.keys(onChangeArg).length) {
-          this.props.onChange(onChangeArg)
+        if (onChangeArg) {
+          this.props.onChange(onChangeArg, this.getState())
         }
       },
     )

--- a/stories/examples/apollo.js
+++ b/stories/examples/apollo.js
@@ -31,7 +31,7 @@ function Examples() {
 
 function ApolloAutocomplete() {
   return (
-    <Autocomplete onChange={({selectedItem}) => alert(selectedItem)}>
+    <Autocomplete onChange={selectedItem => alert(selectedItem)}>
       {({
         inputValue,
         getInputProps,

--- a/stories/examples/basic.js
+++ b/stories/examples/basic.js
@@ -8,8 +8,8 @@ class Examples extends Component {
     selectedColor: '',
   }
 
-  changeHandler = ({selectedItem}) => {
-    this.setState({selectedColor: selectedItem})
+  changeHandler = selectedColor => {
+    this.setState({selectedColor})
   }
 
   render() {

--- a/stories/examples/controlled.js
+++ b/stories/examples/controlled.js
@@ -33,9 +33,9 @@ class Examples extends Component {
   }
   items = ['Black', 'Red', 'Green', 'Blue', 'Orange', 'Purple']
 
-  changeHandler = changes => {
+  changeHandler = selectedColor => {
     this.setState({
-      selectedColor: changes.selectedItem,
+      selectedColor,
       isOpen: false,
     })
   }

--- a/stories/examples/react-instantsearch.js
+++ b/stories/examples/react-instantsearch.js
@@ -8,7 +8,7 @@ export default Examples
 function RawAutoComplete({refine, hits}) {
   return (
     <Autocomplete
-      getValue={i => i.name}
+      itemToString={i => (i ? i.name : i)}
       onChange={item => alert(JSON.stringify(item))}
     >
       {({

--- a/stories/examples/react-popper.js
+++ b/stories/examples/react-popper.js
@@ -1,6 +1,6 @@
 import React, {PureComponent} from 'react'
 import {Manager, Target, Popper} from 'react-popper'
-import Autocomplete from '../../src'
+import Downshift from '../../src'
 
 export default Examples
 
@@ -45,9 +45,8 @@ class ReactPopperAutocomplete extends PureComponent {
         }}
       >
         <Manager>
-          <Autocomplete
-            onChange={({selectedItem}) =>
-              this.setState({selected: selectedItem})}
+          <Downshift
+            onChange={selected => this.setState({selected})}
             style={{display: 'inline-block', position: 'relative'}}
           >
             {({
@@ -96,7 +95,7 @@ class ReactPopperAutocomplete extends PureComponent {
                     </Popper>}
                 </div>
               </div>)}
-          </Autocomplete>
+          </Downshift>
         </Manager>
       </div>
     )


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Removes `previousItem` from the `onChange` callback and instead calls it with just `selectItem, allState`.

<!-- Why are these changes necessary? -->
**Why**: Closes #130

<!-- How were these changes implemented? -->
**How**: simplify things a bit and update examples

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
