### PR TITLE
fix(onChange): only call `onChange` when the selection changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist
 .opt-out
 .DS_Store
 .next
+.eslintcache
 storybook-static
 
 # these cause more harm than good

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -49,7 +49,7 @@ module.exports = {
     },
     lint: {
       description: 'lint the entire project',
-      script: 'eslint .',
+      script: 'eslint . --cache',
     },
     validate: {
       description: oneLine`

--- a/src/__tests__/downshift.misc.js
+++ b/src/__tests__/downshift.misc.js
@@ -80,6 +80,19 @@ test('onChange called when clearSelection is trigered', () => {
   expect(handleChange).toHaveBeenCalledWith(null, expect.any(Object))
 })
 
+test('onChange only called when the selection changes', () => {
+  const handleChange = jest.fn()
+  const {selectItem} = setup({
+    onChange: handleChange,
+  })
+  selectItem('foo')
+  expect(handleChange).toHaveBeenCalledTimes(1)
+  expect(handleChange).toHaveBeenCalledWith('foo', expect.any(Object))
+  handleChange.mockClear()
+  selectItem('foo')
+  expect(handleChange).toHaveBeenCalledTimes(0)
+})
+
 function setup({children = () => <div />, ...props} = {}) {
   let renderArg
   const childSpy = jest.fn(controllerArg => {

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -229,7 +229,10 @@ class Downshift extends Component {
         // we need to call on change if the outside world is controlling any of our state
         // and we're trying to update that state. OR if the selection has changed and we're
         // trying to update the selection
-        if (stateToSet.hasOwnProperty('selectedItem')) {
+        if (
+          stateToSet.hasOwnProperty('selectedItem') &&
+          stateToSet.selectedItem !== state.selectedItem
+        ) {
           onChangeArg = stateToSet.selectedItem
         }
         Object.keys(stateToSet).forEach(key => {


### PR DESCRIPTION
Before, it was calling `onChange` any time there was a
`internalSetState({selectedItem})`
