### PR TITLE
fix(scrollIntoView): take bottom borders into account when scrolling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ scripts are available.
 
 This project uses [Storybook](https://storybook.js.org) for local development. Run the following commands to get setup:
 
-1. `$ cd stories` to change to the `/stores` diretory
+1. `$ cd stories` to change to the `/stories` diretory
 2. `$ npm install` to install the Storybook dependencies
 3. `$ cd ..` to change back to the root directory
 

--- a/src/__tests__/utils.scroll-into-view.js
+++ b/src/__tests__/utils.scroll-into-view.js
@@ -45,6 +45,19 @@ test('aligns to bottom when the node is below the scrollable parent', () => {
   expect(scrollableNode.scrollTop).toBe(25)
 })
 
+test('aligns to bottom when the the node is below the scrollable parent and scrollable parent has a border', () => {
+  const nodeTop = 115
+  const node = getNode({height: 10, top: nodeTop})
+  const scrollableNode = getScrollableNode({
+    height: 100,
+    children: [node],
+    borderBottomWidth: '2px',
+    borderTopWidth: '2px',
+  })
+  scrollIntoView(node, scrollableNode)
+  expect(scrollableNode.scrollTop).toBe(27)
+})
+
 function getScrollableNode(overrides = {}) {
   return getNode({
     height: 100,
@@ -64,6 +77,8 @@ function getNode(
     scrollHeight = height,
     clientHeight = height,
     children = [],
+    borderBottomWidth = 0,
+    borderTopWidth = 0,
   } = {},
 ) {
   const div = document.createElement('div')
@@ -75,8 +90,10 @@ function getNode(
     right: 50,
     bottom: height,
   })
-  div.style.borderTopWidth = 0
+  div.style.borderTopWidth = borderTopWidth
+  div.style.borderBottomWidth = borderBottomWidth
   div.scrollTop = scrollTop
+
   Object.defineProperties(div, {
     clientHeight: {value: clientHeight},
     scrollHeight: {value: scrollHeight},

--- a/src/utils.js
+++ b/src/utils.js
@@ -53,6 +53,10 @@ function scrollIntoView(node, rootNode) {
     scrollParentStyles.borderTopWidth,
     10,
   )
+  const scrollParentBorderBottomWidth = parseInt(
+    scrollParentStyles.borderBottomWidth,
+    10,
+  )
   const scrollParentTop = scrollParentRect.top + scrollParentBorderTopWidth
   const nodeRect = node.getBoundingClientRect()
   const nodeOffsetTop = nodeRect.top + scrollParent.scrollTop
@@ -61,11 +65,19 @@ function scrollIntoView(node, rootNode) {
     // the item is above the scrollable area
     scrollParent.scrollTop = nodeTop
   } else if (
-    nodeTop + nodeRect.height >
+    nodeTop +
+      nodeRect.height +
+      scrollParentBorderTopWidth +
+      scrollParentBorderBottomWidth >
     scrollParent.scrollTop + scrollParentRect.height
   ) {
     // the item is below the scrollable area
-    scrollParent.scrollTop = nodeTop + nodeRect.height - scrollParentRect.height
+    scrollParent.scrollTop =
+      nodeTop +
+      nodeRect.height -
+      scrollParentRect.height +
+      scrollParentBorderTopWidth +
+      scrollParentBorderBottomWidth
   }
   // the item is within the scrollable area (do nothing)
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: scrolling offsets now take bottom border into account

<!-- Why are these changes necessary? -->
**Why**:
Auto scrolling does not offset enough when using larger borders.

Example:

(dropdown borders exaggerated to demonstrate issue)

***Before***:
![image](https://user-images.githubusercontent.com/8746094/29235980-614aede0-7eb9-11e7-8d81-1b30f5e82d0f.png)

***After***:
![image](https://user-images.githubusercontent.com/8746094/29235951-fc92dac0-7eb8-11e7-86f9-e4534fa554af.png)


<!-- How were these changes implemented? -->
**How**:
Added a check for border bottom to the `scrollIntoView` function

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation (N/A)
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

