### PR TITLE
update typings for onChange and onStateChange

### DIFF
--- a/test/basic.test.tsx
+++ b/test/basic.test.tsx
@@ -12,9 +12,8 @@ export default class App extends React.Component<Props, State> {
         items: ['apple', 'orange', 'carrot'],
     };
 
-    onChange = ({ selectedItem, previousItem }: ChangeOptions) => {
+    onChange = (selectedItem: any) => {
         console.log('selectedItem', selectedItem);
-        console.log('previousItem', previousItem);
     };
 
     render() {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -8,8 +8,8 @@ export interface DownshiftProps {
     defaultIsOpen?: boolean;
     getA11yStatusMessage?: (options: A11StatusMessageOptions) => any;
     itemToString?: (item: any) => string;
-    onChange?: (options: ChangeOptions) => void;
-    onStateChange?: (options: StateChangeOptions) => void;
+    onChange?: (selectedItem: any, allState: any) => void;
+    onStateChange?: (options: StateChangeOptions, allState: any) => void;
     onClick?: Function;
     selectedItem?: any;
     isOpen?: boolean;


### PR DESCRIPTION
This PR updates the TypeScript definitions for the `onChange` and `onStateChange` handlers introduced in 620a3ad5e4f50dece867ae9989174a8b35104fb3

- Removed `previousItem` from `onChange` and returns only the `selectedItem` itself
- Both `onChange` and `onStateChange` accepts a 2nd parameter `allState`