### PR TITLE
feat: add `onUserAction` to be notified whenever state could be updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,9 +217,9 @@ but differ slightly.
 - `allState`: This is the full state object of all the state in your `downshift`
   component.
 
-> Note: this function could also be called even though no state actually changes
-> so make sure you check `changes.hasOwnProperty()` to see whether you're
-> interested in the changes.
+> Tip: This function will be called any time _any_ state is changed. The best
+> way to determine whether any particular state was changed, you can use
+> `changes.hasOwnProperty('propName')`.
 
 ### itemCount
 

--- a/src/__tests__/downshift.misc.js
+++ b/src/__tests__/downshift.misc.js
@@ -58,6 +58,7 @@ test('onStateChange called with changes and all the state', () => {
   const itemToSelect = 'foo'
   selectItem(itemToSelect)
   const changes = {
+    type: Downshift.stateChangeTypes.unknown,
     selectedItem: itemToSelect,
     inputValue: itemToSelect,
   }

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -31,6 +31,7 @@ class Downshift extends Component {
     itemToString: PropTypes.func,
     onChange: PropTypes.func,
     onStateChange: PropTypes.func,
+    onUserAction: PropTypes.func,
     onClick: PropTypes.func,
     itemCount: PropTypes.number,
     // things we keep in state for uncontrolled components
@@ -51,6 +52,7 @@ class Downshift extends Component {
     getA11yStatusMessage,
     itemToString: i => (i == null ? '' : String(i)),
     onStateChange: () => {},
+    onUserAction: () => {},
     onChange: () => {},
   }
 
@@ -63,6 +65,7 @@ class Downshift extends Component {
   // down your version of downshift (don't use a
   // version range) to avoid surprise breakages.
   static stateChangeTypes = {
+    unknown: '__autocomplete_unknown__',
     mouseUp: '__autocomplete_mouseup__',
     itemMouseEnter: '__autocomplete_item_mouseenter__',
     keyDownArrowUp: '__autocomplete_keydown_arrow_up__',
@@ -267,6 +270,7 @@ class Downshift extends Component {
         ) {
           onChangeArg = stateToSet.selectedItem
         }
+        stateToSet.type = stateToSet.type || Downshift.stateChangeTypes.unknown
         Object.keys(stateToSet).forEach(key => {
           // onStateChangeArg should only have the state that is
           // actually changing
@@ -296,12 +300,16 @@ class Downshift extends Component {
 
         // only call the onStateChange and onChange callbacks if
         // we have relevant information to pass them.
-        if (Object.keys(onStateChangeArg).length) {
+        const hasMoreStateThanType = Object.keys(onStateChangeArg).length > 1
+        if (hasMoreStateThanType) {
           this.props.onStateChange(onStateChangeArg, this.getState())
         }
         if (onChangeArg !== undefined) {
           this.props.onChange(onChangeArg, this.getState())
         }
+        // this is currently undocumented and therefore subject to change
+        // We'll try to not break it, but just be warned.
+        this.props.onUserAction(onStateChangeArg, this.getState())
       },
     )
   }

--- a/stories/examples/react-autosuggest.js
+++ b/stories/examples/react-autosuggest.js
@@ -15,38 +15,40 @@ class Examples extends Component {
     this.setState({selectedColor})
   }
 
-  onStateChange = changes => {
-    let {selectedColor, inputValue, itemsToShow} = this.state
-    const isClosingMenu = changes.hasOwnProperty('isOpen') && !changes.isOpen
-    if (
-      changes.type === Downshift.stateChangeTypes.keyDownEscape &&
-      !isClosingMenu
-    ) {
-      selectedColor = null
-    }
-    if (changes.hasOwnProperty('inputValue')) {
-      if (changes.type === Downshift.stateChangeTypes.keyDownEscape) {
-        inputValue = this.userInputtedValue
-      } else {
-        inputValue = changes.inputValue
-        this.userInputtedValue = changes.inputValue
+  onUserAction = changes => {
+    this.setState(({inputValue, itemsToShow, selectedColor}) => {
+      selectedColor = changes.selectedItem || selectedColor
+      const isClosingMenu = changes.hasOwnProperty('isOpen') && !changes.isOpen
+      if (
+        changes.type === Downshift.stateChangeTypes.keyDownEscape &&
+        !isClosingMenu
+      ) {
+        selectedColor = null
       }
-    }
-    itemsToShow = this.userInputtedValue
-      ? matchSorter(this.items, this.userInputtedValue)
-      : this.items
-    if (
-      changes.hasOwnProperty('highlightedIndex') &&
-      (changes.type === Downshift.stateChangeTypes.keyDownArrowUp ||
-        changes.type === Downshift.stateChangeTypes.keyDownArrowDown)
-    ) {
-      inputValue = itemsToShow[changes.highlightedIndex]
-    }
-    if (isClosingMenu) {
-      inputValue = selectedColor
-      this.userInputtedValue = selectedColor
-    }
-    this.setState({inputValue, itemsToShow, selectedColor})
+      if (changes.hasOwnProperty('inputValue')) {
+        if (changes.type === Downshift.stateChangeTypes.keyDownEscape) {
+          inputValue = this.userInputtedValue
+        } else {
+          inputValue = changes.inputValue
+          this.userInputtedValue = changes.inputValue
+        }
+      }
+      itemsToShow = this.userInputtedValue
+        ? matchSorter(this.items, this.userInputtedValue)
+        : this.items
+      if (
+        changes.hasOwnProperty('highlightedIndex') &&
+        (changes.type === Downshift.stateChangeTypes.keyDownArrowUp ||
+          changes.type === Downshift.stateChangeTypes.keyDownArrowDown)
+      ) {
+        inputValue = itemsToShow[changes.highlightedIndex]
+      }
+      if (isClosingMenu) {
+        inputValue = selectedColor
+        this.userInputtedValue = selectedColor
+      }
+      return {inputValue, itemsToShow, selectedColor}
+    })
   }
 
   render() {
@@ -77,7 +79,7 @@ class Examples extends Component {
               selectedItem={selectedColor}
               inputValue={inputValue}
               onChange={this.changeHandler}
-              onStateChange={this.onStateChange}
+              onUserAction={this.onUserAction}
             />
           </div>
         </div>
@@ -91,14 +93,14 @@ function BasicAutocomplete({
   inputValue,
   selectedItem,
   onChange,
-  onStateChange,
+  onUserAction,
 }) {
   return (
     <Downshift
       inputValue={inputValue}
       selectedItem={selectedItem}
       onChange={onChange}
-      onStateChange={onStateChange}
+      onUserAction={onUserAction}
     >
       {({
         getInputProps,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: add `onUserAction` to be notified whenever state could be updated

<!-- Why are these changes necessary? -->
**Why**: This allows us to gate `onStateChange` to only be called when state actually changed. Closes #148 

<!-- How were these changes implemented? -->
**How**:
- Pass a `type` 100% of the time (default to `unknown`)
- gate calling `onStateChange`
- always call `onUserAction`.

Not sure I love the name `onUserAction` because this will be called even if things happen programmatically. Hence this is not documented yet...

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
