### PR TITLE
feat(onChange): call with all downshift state and helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,15 +192,19 @@ properties:
 
 ### onChange
 
-> `function(selectedItem: any, allState: object)` | optional, no useful default
+> `function(selectedItem: any, stateAndHelpers: object)` | optional, no useful default
 
 Called when the user selects an item. Called with the item that was selected
 and the new state of `downshift`. (see `onStateChange` for more info on
-`allState`).
+`stateAndHelpers`).
+
+- `selectedItem`: The item that was just selected
+- `stateAndHelpers`: This is the exact same thing you're `children` prop
+  function is called with (see [Child Callback Function](#child-callback-function))
 
 ### onStateChange
 
-> `function(changes: object, allState: object)` | optional, no useful default
+> `function(changes: object, stateAndHelpers: object)` | optional, no useful default
 
 This function is called anytime the internal state changes. This can be useful
 if you're using downshift as a "controlled" component, where you manage some or
@@ -211,9 +215,9 @@ The parameters both take the shape of internal state
 but differ slightly.
 
 - `changes`: These are the properties that actually have changed since the last
-  state change
-- `allState`: This is the full state object of all the state in your `downshift`
-  component.
+  state change.
+- `stateAndHelpers`: This is the exact same thing you're `children` prop
+  function is called with (see [Child Callback Function](#child-callback-function))
 
 > Tip: This function will be called any time _any_ state is changed. The best
 > way to determine whether any particular state was changed, you can use

--- a/src/__tests__/downshift.misc.js
+++ b/src/__tests__/downshift.misc.js
@@ -45,55 +45,6 @@ test('clearSelection with an input node focuses the input node', () => {
   expect(document.activeElement).toBe(input.getDOMNode())
 })
 
-test('onStateChange called with changes and all the state', () => {
-  const handleStateChange = jest.fn()
-  const controlledState = {
-    inputValue: '',
-    selectedItem: null,
-  }
-  const {selectItem} = setup({
-    ...controlledState,
-    onStateChange: handleStateChange,
-  })
-  const itemToSelect = 'foo'
-  selectItem(itemToSelect)
-  const changes = {
-    type: Downshift.stateChangeTypes.unknown,
-    selectedItem: itemToSelect,
-    inputValue: itemToSelect,
-  }
-  const allState = {
-    ...controlledState,
-    isOpen: false,
-    highlightedIndex: null,
-  }
-  expect(handleStateChange).toHaveBeenLastCalledWith(changes, allState)
-})
-
-test('onChange called when clearSelection is trigered', () => {
-  const handleChange = jest.fn()
-  const {clearSelection} = setup({
-    selectedItem: 'foo',
-    onChange: handleChange,
-  })
-  clearSelection()
-  expect(handleChange).toHaveBeenCalledTimes(1)
-  expect(handleChange).toHaveBeenCalledWith(null, expect.any(Object))
-})
-
-test('onChange only called when the selection changes', () => {
-  const handleChange = jest.fn()
-  const {selectItem} = setup({
-    onChange: handleChange,
-  })
-  selectItem('foo')
-  expect(handleChange).toHaveBeenCalledTimes(1)
-  expect(handleChange).toHaveBeenCalledWith('foo', expect.any(Object))
-  handleChange.mockClear()
-  selectItem('foo')
-  expect(handleChange).toHaveBeenCalledTimes(0)
-})
-
 test('toggleMenu can take no arguments at all', () => {
   const {toggleMenu, childSpy} = setup()
   toggleMenu()

--- a/src/__tests__/downshift.props.js
+++ b/src/__tests__/downshift.props.js
@@ -1,0 +1,73 @@
+// this is stuff that I couldn't think fit anywhere else
+// but we still want to have tested.
+
+import React from 'react'
+import {mount} from 'enzyme'
+import Downshift from '../'
+
+test('onStateChange called with changes and downshift state and helpers', () => {
+  const handleStateChange = jest.fn()
+  const controlledState = {
+    inputValue: '',
+    selectedItem: null,
+  }
+  const {selectItem} = setup({
+    ...controlledState,
+    onStateChange: handleStateChange,
+  })
+  const itemToSelect = 'foo'
+  selectItem(itemToSelect)
+  const changes = {
+    type: Downshift.stateChangeTypes.unknown,
+    selectedItem: itemToSelect,
+    inputValue: itemToSelect,
+  }
+  const stateAndHelpers = {
+    ...controlledState,
+    isOpen: false,
+    highlightedIndex: null,
+    selectItem,
+  }
+  expect(handleStateChange).toHaveBeenLastCalledWith(
+    changes,
+    expect.objectContaining(stateAndHelpers),
+  )
+})
+
+test('onChange called when clearSelection is trigered', () => {
+  const handleChange = jest.fn()
+  const {clearSelection} = setup({
+    selectedItem: 'foo',
+    onChange: handleChange,
+  })
+  clearSelection()
+  expect(handleChange).toHaveBeenCalledTimes(1)
+  expect(handleChange).toHaveBeenCalledWith(null, expect.any(Object))
+})
+
+test('onChange only called when the selection changes', () => {
+  const handleChange = jest.fn()
+  const {selectItem} = setup({
+    onChange: handleChange,
+  })
+  selectItem('foo')
+  expect(handleChange).toHaveBeenCalledTimes(1)
+  expect(handleChange).toHaveBeenCalledWith('foo', expect.any(Object))
+  handleChange.mockClear()
+  selectItem('foo')
+  expect(handleChange).toHaveBeenCalledTimes(0)
+})
+
+function setup({children = () => <div />, ...props} = {}) {
+  let renderArg
+  const childSpy = jest.fn(controllerArg => {
+    renderArg = controllerArg
+    return children(controllerArg)
+  })
+  const wrapper = mount(
+    <Downshift {...props}>
+      {childSpy}
+    </Downshift>,
+  )
+  return {childSpy, wrapper, ...renderArg}
+}

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -302,19 +302,19 @@ class Downshift extends Component {
         // we have relevant information to pass them.
         const hasMoreStateThanType = Object.keys(onStateChangeArg).length > 1
         if (hasMoreStateThanType) {
-          this.props.onStateChange(onStateChangeArg, this.getState())
+          this.props.onStateChange(onStateChangeArg, this.getStateAndHelpers())
         }
         if (onChangeArg !== undefined) {
-          this.props.onChange(onChangeArg, this.getState())
+          this.props.onChange(onChangeArg, this.getStateAndHelpers())
         }
         // this is currently undocumented and therefore subject to change
         // We'll try to not break it, but just be warned.
-        this.props.onUserAction(onStateChangeArg, this.getState())
+        this.props.onUserAction(onStateChangeArg, this.getStateAndHelpers())
       },
     )
   }
 
-  getControllerStateAndHelpers() {
+  getStateAndHelpers() {
     const {highlightedIndex, inputValue, selectedItem, isOpen} = this.getState()
     const {itemToString} = this.props
     const {
@@ -707,7 +707,7 @@ class Downshift extends Component {
     this.getLabelProps.called = false
     // and something similar for getInputProps
     this.getInputProps.called = false
-    const element = unwrapArray(children(this.getControllerStateAndHelpers()))
+    const element = unwrapArray(children(this.getStateAndHelpers()))
     if (!element) {
       return null
     }


### PR DESCRIPTION
**What**: calls `onStateChange`, `onChange`, and `onUserAction` with all
the downshift state and helpers.

**Why**: Make it so people don't need to use the downshift reference.
Closes #155

**How**: Instead of calling `this.getState()`, call
`this.getDownshiftStateAndHelpers()`.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
