### PR TITLE
Update README to include redux and react-router examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,8 +280,7 @@ a prop (as indicated above) and that state becomes controlled. As soon as
 its state based on your prop's value rather than its own internal state. You
 will be required to keep the state up to date (this is where `onStateChange`
 comes in really handy), but you can also control the state from anywhere, be
-that state from other components, `redux` (example wanted!), `react-router`
-(example wanted!), or anywhere else.
+that state from other components, `redux`, `react-router`, or anywhere else.
 
 > Note: This is very similar to how normal controlled components work elsewhere
 > in react (like `<input />`). If you want to learn more about this concept, you
@@ -426,13 +425,15 @@ These are values that represent the current state of the downshift component.
 
 Examples exist on [codesandbox.io][examples]:
 
-- [bare bones autocomplete](https://codesandbox.io/s/6z67jvklw3)
-- [multiple selection example](https://codesandbox.io/s/W6gyJ30kn) (uses controlled `selectedItem` API).
-- [downshift Apollo example](https://codesandbox.io/s/m5zrvqj85p)
+- [Bare bones autocomplete](https://codesandbox.io/s/6z67jvklw3)
+- [Multiple selection](https://codesandbox.io/s/W6gyJ30kn) (uses controlled `selectedItem` API).
+- [Integration with Apollo](https://codesandbox.io/s/m5zrvqj85p)
+- [Integration with Redux](https://codesandbox.io/s/0o0w70lp8p)
 - [Integration with `react-instantsearch`](https://codesandbox.io/s/kvn0lpp83) from Algolia
 - [Material UI (1.0.0-beta.4) Combobox Using Downshift](https://codesandbox.io/s/QMGq4kAY)
 - [Integration with `GenieJS`](https://codesandbox.io/s/jRLKrxwgl) ([learn more about `genie` here](https://github.com/kentcdodds/genie))
 - [Handling and displaying errors](https://codesandbox.io/s/zKE37vorr)
+- [Integration with React Router](https://codesandbox.io/s/ww9lwloy8w)
 
 <!--
 


### PR DESCRIPTION
**What**: Update Examples to include Redux and React Router

**Why**: They were missing and the README had call outs to add :smile:

**How**: Used codesandbox

**Checklist**:
- [X] Documentation
- [ ] Tests N/A
- [X] Ready to be merged
- [X] Added myself to contributors table