### PR TITLE
Auto-open menu on focus when input is non-empty

### DIFF
--- a/src/downshift.js
+++ b/src/downshift.js
@@ -528,6 +528,7 @@ class Downshift extends Component {
         onInput,
         this.input_handleChange,
       ),
+      onFocus: this.input_handleFocus,
       onKeyDown: composeEventHandlers(onKeyDown, this.input_handleKeyDown),
       onBlur: composeEventHandlers(onBlur, this.input_handleBlur),
       ...rest,
@@ -547,6 +548,14 @@ class Downshift extends Component {
       isOpen: true,
       inputValue: event.target.value,
     })
+  }
+
+  input_handleFocus = () => {
+    if (this.getState().inputValue.length) {
+      this.internalSetState({
+        isOpen: true,
+      })
+    }
   }
 
   input_handleBlur = () => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

This auto-opens the menu when the input with value is focused. Previously, user has to type something (albeit he already had) to open up the menu.

<!-- Why are these changes necessary? -->
**Why**:

A number of autocomplete components implement this feature, namely react-select. Google does this as well. I also think that this is a convenient UX.

This is easily doable outside Downshift, but I think it should be part of the core. In addition, we can add a prop that allows users to disable this option.

<!-- How were these changes implemented? -->
**How**:

By adding a new focus event listener.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

Not yet, I'd like to make this as a discussion starter - it's a pretty simple change anyway.

If this sounds good, I'd be happy to push tests.

<!-- feel free to add additional comments -->

Will put up GIFs within the hour (haha, never done them with Windows).