### PR TITLE
Add multiple example

### DIFF
--- a/stories/config.js
+++ b/stories/config.js
@@ -7,6 +7,7 @@ import {storiesOf} from '@storybook/react'
 import Basic from './examples/basic'
 import Form from './examples/form'
 import Controlled from './examples/controlled'
+import Multiple from './examples/multiple'
 import Autosuggest from './examples/react-autosuggest'
 import SemanticUI from './examples/semantic-ui'
 import Apollo from './examples/apollo'
@@ -24,6 +25,7 @@ function loadStories() {
     .add('basic', () => <Basic />)
     .add('form', () => <Form />)
     .add('controlled', () => <Controlled />)
+    .add('multiple', () => <Multiple />)
     .add('autosuggest', () => <Autosuggest />)
     .add('semantic-ui', () => <SemanticUI />)
     .add('apollo', () => <Apollo />)
@@ -31,9 +33,9 @@ function loadStories() {
     .add('instant search', () => <InstantSearch />)
     .add('react-popper', () => <Popper />)
     .add('windowing with react-virtualized', () => <ReactVirtualized />)
-    .add('windowing with react-tiny-virtual-list', () => (
-      <ReactTinyVirtualList />
-    ))
+    .add('windowing with react-tiny-virtual-list', () =>
+      <ReactTinyVirtualList />,
+    )
 }
 
 configure(loadStories, module)

--- a/stories/examples/multiple.js
+++ b/stories/examples/multiple.js
@@ -1,0 +1,231 @@
+import React, {Component} from 'react'
+import glamorous, {Div} from 'glamorous'
+import matchSorter from 'match-sorter'
+import Autocomplete from '../../src'
+
+class Examples extends Component {
+  state = {
+    selectedColors: [],
+  }
+
+  changeHandler = selectedColors => {
+    this.setState({selectedColors})
+  }
+
+  render() {
+    const items = ['Black', 'Red', 'Green', 'Blue', 'Orange', 'Purple']
+
+    return (
+      <div>
+        <Div
+          css={{
+            margin: '50px auto',
+            maxWidth: 600,
+            textAlign: 'center',
+          }}
+        >
+          <h2>multiple example</h2>
+          <Div display="flex" justifyContent="center">
+            <MultipleAutocomplete
+              values={this.state.selectedColors}
+              items={items}
+              onChange={this.changeHandler}
+            />
+          </Div>
+        </Div>
+      </div>
+    )
+  }
+}
+
+const Label = glamorous.label({fontWeight: 'bold', display: 'block'})
+
+const Item = glamorous.div(
+  {
+    cursor: 'pointer',
+    display: 'flex',
+    alignItems: 'center',
+    border: 'none',
+    height: 'auto',
+    textAlign: 'left',
+    borderTop: 'none',
+    lineHeight: '1em',
+    color: 'rgba(0,0,0,.87)',
+    fontSize: '1rem',
+    textTransform: 'none',
+    fontWeight: '400',
+    boxShadow: 'none',
+    padding: '.8rem 1.1rem',
+    boxSizing: 'border-box',
+    whiteSpace: 'normal',
+    wordWrap: 'normal',
+  },
+  ({isActive, isSelected}) => ({
+    opacity: isSelected ? 0.5 : 1,
+    backgroundColor: isActive ? 'lightgrey' : 'white',
+    '&:hover, &:focus': {
+      borderColor: '#96c8da',
+      boxShadow: '0 2px 3px 0 rgba(34,36,38,.15)',
+    },
+  }),
+)
+
+const ItemLabel = glamorous.span({
+  display: 'inlineBlock',
+  padding: '4px 6px',
+  color: '#fff',
+  background: '#ddd',
+  textTransform: 'uppercase',
+  borderRadius: 'borderRadius',
+  marginLeft: 'auto',
+  fontSize: 10,
+})
+
+const InputWrapper = glamorous.div({
+  lineHeight: '1em',
+  outline: 0,
+  minHeight: '2em',
+  background: '#fff',
+  display: 'flex',
+  alignItems: 'center',
+  padding: '.5em',
+  border: '1px solid rgba(34,36,38,.15)',
+  transition: 'box-shadow .1s ease,width .1s ease',
+})
+
+const Input = glamorous.input({
+  fontSize: 14,
+  wordWrap: 'break-word',
+  outline: 0,
+  whiteSpace: 'normal',
+  background: 'transparent',
+  display: 'inline-block',
+  color: 'rgba(0,0,0,.87)',
+  boxShadow: 'none',
+  border: '0',
+})
+
+// this is just a demo of how you'd use the getRootProps function
+// normally you wouldn't need this kind of abstraction 😉
+function Root({innerRef, ...rest}) {
+  return <div ref={innerRef} {...rest} />
+}
+
+class MultipleAutocomplete extends React.Component {
+  state = {
+    input: '',
+  }
+
+  render() {
+    const {values} = this.props
+    const {input} = this.state
+    const items = input.length
+      ? matchSorter(this.props.items, input)
+      : this.props.items
+    const indices = mapItemIndex(items, values)
+
+    return (
+      <Autocomplete inputValue={this.state.input} onChange={this.handleChange}>
+        {({
+          getInputProps,
+          getItemProps,
+          getRootProps,
+          getLabelProps,
+          highlightedIndex,
+          isOpen,
+        }) =>
+          (<Root {...getRootProps({refKey: 'innerRef'})}>
+            <Label {...getLabelProps()}>What are your favorite colors?</Label>
+            <InputWrapper>
+              {values.map((value, i) =>
+                (<span
+                  key={i}
+                  style={{
+                    height: '2em',
+                    width: '2em',
+                    padding: '.3em',
+                    borderRadius: '5px',
+                    marginRight: '.5em',
+                    backgroundColor: value,
+                  }}
+                />),
+              )}
+              <Input
+                {...getInputProps({
+                  placeholder: 'Enter color here',
+                  onChange: this.handleInputChange,
+                  onKeyDown: this.handleKeyDown,
+                })}
+              />
+            </InputWrapper>
+
+            {isOpen &&
+              <div
+                style={{
+                  border: '1px solid rgba(34,36,38,.15)',
+                  maxHeight: 400,
+                  overflowY: 'scroll',
+                }}
+              >
+                {items.map((item, index) => {
+                  const selected = this.props.values.indexOf(item) !== -1
+
+                  const props = selected
+                    ? {}
+                    : getItemProps({
+                        item,
+                        index: indices[item],
+                        isActive: highlightedIndex === indices[item],
+                        isSelected: selected,
+                      })
+
+                  return (
+                    <Item {...props} key={item}>
+                      {item}
+                      {selected && <ItemLabel>Selected</ItemLabel>}
+                    </Item>
+                  )
+                })}
+              </div>}
+          </Root>)}
+      </Autocomplete>
+    )
+  }
+
+  handleKeyDown = evt => {
+    const {values} = this.props
+    if (values.length && !this.state.input.length && evt.keyCode == 8) {
+      this.props.onChange(values.slice(0, values.length - 1))
+    }
+  }
+
+  handleInputChange = evt => {
+    this.setState({input: evt.target.value})
+  }
+
+  handleChange = item => {
+    this.props.onChange([...this.props.values, item])
+    this.setState({input: ''})
+  }
+}
+
+/**
+ * Get the real index of an item.
+ *
+ * It does this filtering out selected values, and mapping the values to the index.
+ * We're doing so that Downshift doesn't recognize selected item,
+ * thus won't highlight the selected item.
+ *
+ * Given that ['Black', 'Blue', 'Green'], and 'Blue' is selected
+ * Output: { 'Black': 0, 'Green': 1 }
+ */
+function mapItemIndex(items, values) {
+  return items
+    .filter(item => values.indexOf(item) === -1)
+    .reduce((prev, next, i) => {
+      prev[next] = i
+      return prev
+    }, {})
+}
+
+export default Examples


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

Adds an example of a multiple (aka tagging) autocomplete with Downshift.

Preview (GIF):

![2017-09-04_14-56-45](https://user-images.githubusercontent.com/5093058/30015181-3b5157ec-9182-11e7-87fb-32d3a5b9a2cb.gif)

<!-- Why are these changes necessary? -->
**Why**:

No examples of a multiple autocomplete yet.

Prior discussion in #139.

<!-- How were these changes implemented? -->
**How**:

- Selected items are ignored - they're not highlighted by Downshift
- Backspace to delete last item added
- Input value is controlled so we can clear them

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation (N/A)
- [ ] Tests (N/A)
- [ ] Ready to be merged<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

It may be lacking some simple convenience such as focusing automatically to the input when any part of the box is clicked.