### PR TITLE
Fix TS build issue

### DIFF
--- a/test/basic.test.tsx
+++ b/test/basic.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Downshift, { ChangeOptions, ControllerStateAndHelpers } from '../';
+import Downshift, { ControllerStateAndHelpers } from '../';
 
 interface Props {}
 

--- a/test/custom.test.tsx
+++ b/test/custom.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Downshift, { ChangeOptions, ControllerStateAndHelpers } from '../';
+import Downshift, { ControllerStateAndHelpers } from '../';
 
 interface Props {}
 


### PR DESCRIPTION
TypeScript tests should not import `ChangeOptions`, since that property has been removed.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Fix TypeScript tests

<!-- Why are these changes necessary? -->
**Why**: There was a build issue in https://github.com/paypal/downshift/pull/165

<!-- How were these changes implemented? -->
**How**: Remove references to removed `ChangeOptions`

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
