### PR TITLE
feat(pickState): only pick relevant state

### DIFF
--- a/src/__tests__/utils.pick-state.js
+++ b/src/__tests__/utils.pick-state.js
@@ -1,0 +1,16 @@
+import {pickState} from '../utils'
+
+test('pickState only picks state that downshift cares about', () => {
+  const otherStateToSet = {
+    isOpen: true,
+    foo: 0,
+  }
+  const result = pickState(otherStateToSet)
+  const expected = {isOpen: true}
+  const resultKeys = Object.keys(result)
+  const expectedKeys = Object.keys(expected) 
+  resultKeys.sort()
+  expectedKeys.sort()
+  expect(result).toEqual(expected)
+  expect(resultKeys).toEqual(expectedKeys)
+})

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -18,6 +18,7 @@ import {
   getElementProps,
   noop,
   requiredProp,
+  pickState,
 } from './utils'
 
 class Downshift extends Component {
@@ -154,6 +155,7 @@ class Downshift extends Component {
     highlightedIndex = this.props.defaultHighlightedIndex,
     otherStateToSet = {},
   ) => {
+    otherStateToSet = pickState(otherStateToSet)
     this.internalSetState({highlightedIndex, ...otherStateToSet}, () => {
       const node = this.getItemNodeFromIndex(this.getState().highlightedIndex)
       const rootNode = this._rootNode
@@ -213,6 +215,7 @@ class Downshift extends Component {
   }
 
   selectItem = (item, otherStateToSet, cb) => {
+    otherStateToSet = pickState(otherStateToSet)
     this.internalSetState(
       {
         isOpen: false,
@@ -596,6 +599,7 @@ class Downshift extends Component {
   //\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ ITEM
 
   reset = (otherStateToSet = {}, cb) => {
+    otherStateToSet = pickState(otherStateToSet)
     this.internalSetState(
       ({selectedItem}) => ({
         isOpen: false,
@@ -608,6 +612,7 @@ class Downshift extends Component {
   }
 
   toggleMenu = (otherStateToSet = {}, cb) => {
+    otherStateToSet = pickState(otherStateToSet)
     this.internalSetState(
       ({isOpen}) => {
         return {isOpen: !isOpen, ...otherStateToSet}

--- a/src/utils.js
+++ b/src/utils.js
@@ -229,6 +229,27 @@ function requiredProp(fnName, propName) {
   throw new Error(`The property "${propName}" is required in "${fnName}"`)
 }
 
+const stateKeys = [
+  'highlightedIndex',
+  'inputValue',
+  'isOpen',
+  'selectedItem',
+  'type',
+]
+/**
+ * @param {Object} state The state object
+ * @return {Object} State that is relevant to downshift
+ */
+function pickState(state = {}) {
+  const result = {}
+  stateKeys.forEach((k) => {
+    if (state.hasOwnProperty(k)) {
+      result[k] = state[k]
+    }
+  })
+  return result
+}
+
 export {
   cbToCb,
   findParent,
@@ -245,4 +266,5 @@ export {
   noop,
   requiredProp,
   setIdCounter,
+  pickState,
 }


### PR DESCRIPTION
Make `toggleMenu` and friends more user-friendly by only picking out
state that is relevant to downshift, allowing users to use them as event
event handlers. See #182.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Make `toggleMenu` and friends more user-friendly.

<!-- Why are these changes necessary? -->
**Why**:  See #182.

<!-- How were these changes implemented? -->
**How**: Add `pickState` and call it whenever we are about to spread `otherStateToSet` into `internalSetState`

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

Additional comments:

1. When I initially pulled the most recent from master, `npm run validate` failed.

	    FAIL  other\__tests__\build.js
  	     ● Test suite failed to run

	     Cannot find module '../../dist/downshift.es' from 'build.js'

	       at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:179:17)
	       at Object.<anonymous> (other/__tests__/build.js:14:18)

  	    FAIL  other\__tests__\preact.js
	     ● Test suite failed to run

	     Cannot find module '../../dist/downshift.preact.cjs' from 'preact.js'

	       at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:179:17)
	       at Object.<anonymous> (other/__tests__/preact.js:22:24)

    I investigated a bit. Only the `build-and-test` task is failing. `lint`, `test:cover`, and `test:ts` succeed. I decided to ignore it while developing because I could still run the other test tasks, thinking it could just be a problem with my machine. *Please let me know if we should address this first.*
2. I wanted to add direct tests on `toggleMenu` and others to `downshift.misc.js` (in addition to adding `utils.pick-state.js`), but there wasn't a way to test what object was being passed to `internalSetState`. No matter what the internal state is, we always pass the correct keys to `render` (https://github.com/paypal/downshift/blob/master/src/downshift.js#L336). So, with the current test setup, I couldn't find a way to see what the internals were. I decided it was OK, thinking the new test was sufficient, but let me know if you think otherwise.
3. Locally, I added a new story to test the changes. It didn't seem appropriate to include it in the commit, but let me know if you think otherwise.