### PR TITLE
reset selected as empty str, not null

### DIFF
--- a/stories/examples/react-autosuggest.js
+++ b/stories/examples/react-autosuggest.js
@@ -23,7 +23,7 @@ class Examples extends Component {
         changes.type === Downshift.stateChangeTypes.keyDownEscape &&
         !isClosingMenu
       ) {
-        selectedColor = null
+        selectedColor = ''
       }
       if (changes.hasOwnProperty('inputValue')) {
         if (changes.type === Downshift.stateChangeTypes.keyDownEscape) {


### PR DESCRIPTION
**What**:
Fixes warning: `value prop on input should not be null`. On escape event, set selected to empty string, not null.

**Why**:
Fixes this bug (which I can't repro every time for some reason but happens often. This seems to have fixed it though).
<img width="352" alt="downshift_1" src="https://user-images.githubusercontent.com/6256145/30411715-97e9d9c4-98c7-11e7-90ba-3e984db8428a.png">
