### PR TITLE
Use selectedItem for values in multiple example story

### DIFF
--- a/stories/examples/multiple.js
+++ b/stories/examples/multiple.js
@@ -125,7 +125,11 @@ class MultipleAutocomplete extends React.Component {
     const indices = mapItemIndex(items, values)
 
     return (
-      <Autocomplete inputValue={this.state.input} onChange={this.handleChange}>
+      <Autocomplete
+        inputValue={this.state.input}
+        onChange={this.handleChange}
+        selectedItem={values}
+      >
         {({
           getInputProps,
           getItemProps,
@@ -133,11 +137,12 @@ class MultipleAutocomplete extends React.Component {
           getLabelProps,
           highlightedIndex,
           isOpen,
+          selectedItem,
         }) => (
           <Root {...getRootProps({refKey: 'innerRef'})}>
             <Label {...getLabelProps()}>What are your favorite colors?</Label>
             <InputWrapper>
-              {values.map((value, i) => (
+              {selectedItem.map((value, i) => (
                 <span
                   key={i}
                   style={{


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Use `selectedItem` in the multiple example

<!-- Why are these changes necessary? -->
**Why**: Because I got some weird behaviour with the last item not being added

<!-- How were these changes implemented? -->
**How**: Use `selectedItem` instead of `values` directly

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
To reproduce: in the [multiple story](https://downshift.netlify.com/?selectedKind=Examples&selectedStory=multiple&full=0&down=1&left=1&panelRight=0), try adding all the colors, then remove the last one. Try re-adding it, and notice it doesn't get added. I guess downshift does some _magic behind the scenes™_, keeping the selected items in sync. According to the [multiple example in the readme](https://codesandbox.io/s/W6gyJ30kn), you can use `selectedItem` even tho it's kind of weird that it can have multiple values given the singular name ;)

![input](https://user-images.githubusercontent.com/230841/30533047-b849e6c6-9c57-11e7-95d9-9cf7b5d70af0.gif)
