### PR TITLE
feat: use onClick handler on items rather than on root

### DIFF
--- a/src/__tests__/__snapshots__/downshift.get-root-props.js.snap
+++ b/src/__tests__/__snapshots__/downshift.get-root-props.js.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`not applying the onClick prop results in an error 1`] = `"downshift: You must apply the \\"onClick\\" prop from getRootProps onto your root element."`;
-
 exports[`not applying the ref prop results in an error 1`] = `"downshift: You must apply the ref prop \\"ref\\" from getRootProps onto your root element."`;
 
 exports[`returning a DOM element and calling getRootProps with a refKey results in an error 1`] = `"downshift: You returned a DOM element. You should not specify a refKey in getRootProps. You specified \\"blah\\""`;

--- a/src/__tests__/downshift.get-root-props.js
+++ b/src/__tests__/downshift.get-root-props.js
@@ -47,18 +47,6 @@ test('not applying the ref prop results in an error', () => {
   expect(() => mount(<MyComponent />)).toThrowErrorMatchingSnapshot()
 })
 
-test('not applying the onClick prop results in an error', () => {
-  const MyComponent = () => (
-    <Downshift>
-      {({getRootProps}) => {
-        const {ref} = getRootProps()
-        return <div ref={ref} />
-      }}
-    </Downshift>
-  )
-  expect(() => mount(<MyComponent />)).toThrowErrorMatchingSnapshot()
-})
-
 test('renders fine when rendering a composite component and applying getRootProps properly', () => {
   const MyComponent = () => (
     <Downshift>

--- a/src/utils.js
+++ b/src/utils.js
@@ -146,12 +146,6 @@ function firstDefined(...args) {
   return args.find(a => typeof a !== 'undefined')
 }
 
-function isNumber(thing) {
-  // not NaN and is a number type
-  // eslint-disable-next-line no-self-compare
-  return thing === thing && typeof thing === 'number'
-}
-
 // eslint-disable-next-line complexity
 function getA11yStatusMessage({
   isOpen,
@@ -242,7 +236,7 @@ const stateKeys = [
  */
 function pickState(state = {}) {
   const result = {}
-  stateKeys.forEach((k) => {
+  stateKeys.forEach(k => {
     if (state.hasOwnProperty(k)) {
       result[k] = state[k]
     }
@@ -252,13 +246,11 @@ function pickState(state = {}) {
 
 export {
   cbToCb,
-  findParent,
   composeEventHandlers,
   debounce,
   scrollIntoView,
   generateId,
   firstDefined,
-  isNumber,
   getA11yStatusMessage,
   unwrapArray,
   isDOMElement,


### PR DESCRIPTION

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: This swaps our document querying stuff from the root element with a more explicit `onClick` handler on the items.

<!-- Why are these changes necessary? -->
**Why**: It probably should have always been this way...

<!-- How were these changes implemented? -->
**How**: Make the changes, see only one test broke, turns out that's unnecessary with the changes now so we can delete it.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

This should also make it easier to implement #185 :+1:

cc @gricard and @Swizec :smile: