### PR TITLE
Reset highlightedIndex to defaultHighlightIndex after selecting item

### DIFF
--- a/src/__tests__/downshift.get-item-props.js
+++ b/src/__tests__/downshift.get-item-props.js
@@ -50,6 +50,19 @@ test('on mouseenter of an item updates the highlightedIndex to that item', () =>
   )
 })
 
+test('after selecting an item highlightedIndex should be reset to defaultHighlightIndex', () => {
+  const {Component, childSpy} = setup()
+  const wrapper = mount(<Component defaultHighlightedIndex={1} />)
+  const firstButton = wrapper.find('button').first()
+  childSpy.mockClear()
+  firstButton.simulate('click')
+  expect(childSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      highlightedIndex: 1,
+    }),
+  )
+})
+
 test('getItemProps throws a helpful error when no object is given', () => {
   expect(() =>
     mount(

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -217,7 +217,7 @@ class Downshift extends Component {
     this.internalSetState(
       {
         isOpen: false,
-        highlightedIndex: null,
+        highlightedIndex: this.props.defaultHighlightedIndex,
         selectedItem: item,
         inputValue: this.props.itemToString(item),
         ...otherStateToSet,


### PR DESCRIPTION

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Fixes #194

<!-- Why are these changes necessary? -->
**Why**:

As a user I'd expect `highlightedIndex` to always have the value that I initially set it to, after selecting an item. I.e. react-select also works like this. It allows the user to quickly hit enter when the right item is the first in the list.

<!-- How were these changes implemented? -->
**How**:

`highlightedIndex` was always set to `null` when selecting an item. I changed that to be set to the `defaultHighlightedIndex`prop.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
