### PR TITLE
fix(ssr): add type check for window

### DIFF
--- a/other/ssr/__tests__/index.js
+++ b/other/ssr/__tests__/index.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import ReactDOMServer from 'react-dom/server'
+import Downshift from '../../../src'
+
+test('does not throw an error when server rendering', () => {
+  expect(() => {
+    ReactDOMServer.renderToString(
+      <Downshift id="my-autocomplete-component">
+        {({getInputProps, getLabelProps}) => (
+          <div>
+            <label {...getLabelProps({htmlFor: 'my-autocomplete-input'})} />
+            <input {...getInputProps({id: 'my-autocomplete-input'})} />
+          </div>
+        )}
+      </Downshift>
+    )
+  }).not.toThrow()
+})
+
+/* eslint jsx-a11y/label-has-for:0 */

--- a/other/ssr/jest.config.js
+++ b/other/ssr/jest.config.js
@@ -1,0 +1,9 @@
+// This is separate because the test environment is set via the config
+// and we want most of our tests to run with jsdom, but we still want
+// to make sure that the server rendering use case continues to work.
+const jestConfig = require('kcd-scripts/config').jest
+
+module.exports = Object.assign(jestConfig, {
+  roots: ['.'],
+  testEnvironment: 'node',
+})

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -63,7 +63,10 @@ class Downshift extends Component {
     onStateChange: () => {},
     onUserAction: () => {},
     onChange: () => {},
-    environment: window,
+    environment:
+      typeof window === 'undefined' /* istanbul ignore next (ssr) */
+        ? {}
+        : window,
   }
 
   // this is an experimental feature


### PR DESCRIPTION
**What**: adds a `typeof` check for `window`

<!-- Why are these changes necessary? -->
**Why**: Fixes issue found with SSR in #204 

<!-- How were these changes implemented? -->
**How**: add typeof in the default. Also adds tests to avoid breaking SSR in the future

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
