### PR TITLE
add editable multi select example

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,7 @@ Examples exist on [codesandbox.io][examples]:
 - [Section/option group example](https://codesandbox.io/s/zx1kj58npl)
 - [Integration with `fuzzaldrin-plus` (Fuzzy matching)](https://codesandbox.io/s/pyq3v4o3j)
 - [Dropdown/select implementation with Bootstrap](https://codesandbox.io/s/53y8jvpj0k)
+- [Multiple editable tag selection](https://codesandbox.io/s/o4yp9vmm8z)
 
 <!--
 


### PR DESCRIPTION
**What**: Add a multi editable select tags example

**Checklist**:
- [X] Documentation
- [ ] Tests - N/A
- [X] Ready to be merged
- [ ] Added myself to contributors table

In case some changes need to be made in the example, please let me know.
I'm not sure if its somehow possible to make the example editable by other people (In case something needs to be fixed / changed in the example in the future).. Or we'll just need to put a different link.
