### PR TITLE
fix: cursor jumping to end of input

### DIFF
--- a/src/__tests__/downshift.props.js
+++ b/src/__tests__/downshift.props.js
@@ -90,6 +90,26 @@ test('can override onOuterClick callback to maintain isOpen state', () => {
   )
 })
 
+test('onInputValueChange called when changes contain inputValue', () => {
+  const handleInputValueChange = jest.fn()
+  const {selectItem} = setup({
+    onInputValueChange: handleInputValueChange,
+  })
+  selectItem('foo')
+  expect(handleInputValueChange).toHaveBeenCalledTimes(1)
+  expect(handleInputValueChange).toHaveBeenCalledWith('foo', expect.any(Object))
+})
+
+test('onInputValueChange not called when changes do not contain inputValue', () => {
+  const handleInputValueChange = jest.fn()
+  const {openMenu} = setup({
+    onInputValueChange: handleInputValueChange,
+  })
+  openMenu()
+
+  expect(handleInputValueChange).toHaveBeenCalledTimes(0)
+})
+
 function mouseDownAndUp(node) {
   node.dispatchEvent(new window.MouseEvent('mousedown', {bubbles: true}))
   node.dispatchEvent(new window.MouseEvent('mouseup', {bubbles: true}))

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -31,6 +31,7 @@ class Downshift extends Component {
     itemToString: PropTypes.func,
     onChange: PropTypes.func,
     onStateChange: PropTypes.func,
+    onInputValueChange: PropTypes.func,
     onUserAction: PropTypes.func,
     onClick: PropTypes.func,
     onOuterClick: PropTypes.func,
@@ -62,6 +63,7 @@ class Downshift extends Component {
     id: generateId('downshift'),
     itemToString: i => (i == null ? '' : String(i)),
     onStateChange: () => {},
+    onInputValueChange: () => {},
     onUserAction: () => {},
     onChange: () => {},
     onOuterClick: () => {},
@@ -268,6 +270,14 @@ class Downshift extends Component {
   internalSetState(stateToSet, cb) {
     let onChangeArg
     const onStateChangeArg = {}
+
+    if (stateToSet.hasOwnProperty('inputValue')) {
+      this.props.onInputValueChange(
+        stateToSet.inputValue,
+        this.getStateAndHelpers(),
+      )
+    }
+
     return this.setState(
       state => {
         state = this.getState(state)


### PR DESCRIPTION
#217

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Provide an onInputValueChange callback to allow to update controlled prop before its old value is used to re-render the children, causing the cursor in the input to jump to the end in the next render.
<!-- Why are these changes necessary? -->
**Why**:
fixes #217 
<!-- How were these changes implemented? -->
<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [x] Tests
- [ ] Ready to be merged -> docs missing <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
@kentcdodds I'd like to get your opinion on this change before adding documentation for it.
Do you think this is a direction worth pursuing?