### PR TITLE
Fix cursor jumping to end of input

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,16 @@ but differ slightly.
 > so it's not recommended to use it if you can avoid it. If you need it, please
 > open an issue to discuss solidifying the API.
 
+### onInputValueChange
+
+> `function(inputValue: string, stateAndHelpers: object)` | optional, no useful default
+
+Called whenever the input value changes. Useful to use instead or in combination of `onStateChange` when `inputValue` is a controlled prop to [avoid issues with cursor positions](https://github.com/paypal/downshift/issues/217). 
+
+- `inputValue`: The current value of the input
+- `stateAndHelpers`: This is the same thing your `children` prop
+  function is called with (see [Child Callback Function](#child-callback-function))
+
 ### itemCount
 
 > `number` | optional, defaults the number of times you call getItemProps

--- a/src/__tests__/downshift.props.js
+++ b/src/__tests__/downshift.props.js
@@ -90,6 +90,39 @@ test('can override onOuterClick callback to maintain isOpen state', () => {
   )
 })
 
+test('onInputValueChange called when changes contain inputValue', () => {
+  const handleInputValueChange = jest.fn()
+  const {selectItem} = setup({
+    onInputValueChange: handleInputValueChange,
+  })
+  selectItem('foo')
+  expect(handleInputValueChange).toHaveBeenCalledTimes(1)
+  expect(handleInputValueChange).toHaveBeenCalledWith(
+    'foo',
+    expect.any(Object),
+  )
+})
+
+test('onInputValueChange not called when changes do not contain inputValue', () => {
+  const handleInputValueChange = jest.fn()
+  const {openMenu} = setup({
+    onInputValueChange: handleInputValueChange,
+  })
+  openMenu()
+
+  expect(handleInputValueChange).toHaveBeenCalledTimes(0)
+})
+
+test('onInputValueChange called with empty string on reset', () => {
+  const handleInputValueChange = jest.fn()
+  const {reset} = setup({
+    onInputValueChange: handleInputValueChange,
+  })
+  reset()
+  expect(handleInputValueChange).toHaveBeenCalledTimes(1)
+  expect(handleInputValueChange).toHaveBeenCalledWith('', expect.any(Object))
+})
+
 function mouseDownAndUp(node) {
   node.dispatchEvent(new window.MouseEvent('mousedown', {bubbles: true}))
   node.dispatchEvent(new window.MouseEvent('mouseup', {bubbles: true}))

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -31,6 +31,7 @@ class Downshift extends Component {
     itemToString: PropTypes.func,
     onChange: PropTypes.func,
     onStateChange: PropTypes.func,
+    onInputValueChange: PropTypes.func,
     onUserAction: PropTypes.func,
     onClick: PropTypes.func,
     onOuterClick: PropTypes.func,
@@ -62,6 +63,7 @@ class Downshift extends Component {
     id: generateId('downshift'),
     itemToString: i => (i == null ? '' : String(i)),
     onStateChange: () => {},
+    onInputValueChange: () => {},
     onUserAction: () => {},
     onChange: () => {},
     onOuterClick: () => {},
@@ -268,11 +270,18 @@ class Downshift extends Component {
   internalSetState(stateToSet, cb) {
     let onChangeArg
     const onStateChangeArg = {}
+    const isSetToStateFunction = typeof stateToSet === 'function'
+
+    if (!isSetToStateFunction && stateToSet.hasOwnProperty('inputValue')) {
+      this.props.onInputValueChange(stateToSet.inputValue, {
+        ...this.getStateAndHelpers(),
+        ...stateToSet,
+      })
+    }
     return this.setState(
       state => {
         state = this.getState(state)
-        stateToSet =
-          typeof stateToSet === 'function' ? stateToSet(state) : stateToSet
+        stateToSet = isSetToStateFunction ? stateToSet(state) : stateToSet
         // this keeps track of the object we want to call with setState
         const nextState = {}
         // this is just used to tell whether the state changed
@@ -287,6 +296,7 @@ class Downshift extends Component {
           onChangeArg = stateToSet.selectedItem
         }
         stateToSet.type = stateToSet.type || Downshift.stateChangeTypes.unknown
+
         Object.keys(stateToSet).forEach(key => {
           // onStateChangeArg should only have the state that is
           // actually changing
@@ -308,6 +318,14 @@ class Downshift extends Component {
             nextState[key] = stateToSet[key]
           }
         })
+
+        if (isSetToStateFunction && stateToSet.hasOwnProperty('inputValue')) {
+          this.props.onInputValueChange(stateToSet.inputValue, {
+            ...this.getStateAndHelpers(),
+            ...stateToSet,
+          })
+        }
+
         return nextState
       },
       () => {


### PR DESCRIPTION
#217

Continuation of https://github.com/paypal/downshift/pull/229

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Provide an onInputValueChange callback to allow to update controlled prop before its old value is used to re-render the children, causing the cursor in the input to jump to the end in the next render.
<!-- Why are these changes necessary? -->
**Why**:
fixes #217 
<!-- How were these changes implemented? -->
<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [x] Tests
- [ ] Ready to be merged -> docs missing <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
@kentcdodds I'd like to get your opinion on this change before adding documentation for it.
Do you think this is a direction worth pursuing?