### PR TITLE
Add onOuterClick to DownshiftProps typing

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -12,6 +12,7 @@ export interface DownshiftProps {
     selectedItem: any,
     stateAndHelpers: ControllerStateAndHelpers,
   ) => void
+  onOuterClick?: () => void
   onStateChange?: (
     options: StateChangeOptions,
     stateAndHelpers: ControllerStateAndHelpers,


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: update typing to include onOuterClick

<!-- Why are these changes necessary? -->
**Why**: it was missing and typescript won't compile if you try to add the onOuterClick prop to the Downshift component

<!-- How were these changes implemented? -->
**How**: added typing to include onOuterClick

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions --> N/A

<!-- feel free to add additional comments -->
