### PR TITLE
fix(selectItemAtIndex): allow selecting empty string

### DIFF
--- a/src/__tests__/downshift.misc.js
+++ b/src/__tests__/downshift.misc.js
@@ -75,8 +75,15 @@ test('toggleMenu can take no arguments at all', () => {
 })
 
 test('clearItems clears the all items', () => {
-  const items = ['Chess']
-  const {wrapper, clearItems} = setup({items})
+  const item = 'Chess'
+  const children = ({getItemProps}) => (
+    <div>
+      <div key={item} {...getItemProps({item})}>
+        {item}
+      </div>
+    </div>
+  )
+  const {wrapper, clearItems} = setup({children})
   clearItems()
   expect(wrapper.instance().items).toEqual([])
 })

--- a/src/__tests__/downshift.misc.js
+++ b/src/__tests__/downshift.misc.js
@@ -32,6 +32,24 @@ test('selectItemAtIndex does nothing if there is no item at that index', () => {
   expect(childSpy).not.toHaveBeenCalled()
 })
 
+test('selectItemAtIndex can select item that is an empty string', () => {
+  const items = ['Chess', '']
+  const children = ({getItemProps}) => (
+    <div>
+      {items.map((item, index) => (
+        <div key={index} {...getItemProps({item})}>
+          {item}
+        </div>
+      ))}
+    </div>
+  )
+  const {selectItemAtIndex, childSpy} = setup({children})
+  selectItemAtIndex(1)
+  expect(childSpy).toHaveBeenLastCalledWith(
+    expect.objectContaining({selectedItem: ''}),
+  )
+})
+
 test('clearSelection with an input node focuses the input node', () => {
   const children = ({getInputProps}) => (
     <div>

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -245,7 +245,7 @@ class Downshift extends Component {
 
   selectItemAtIndex = (itemIndex, otherStateToSet, cb) => {
     const item = this.items[itemIndex]
-    if (!item) {
+    if (item == null) {
       return
     }
     this.selectItem(item, otherStateToSet, cb)


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
I'm currently unable to select an item if it's only an empty string.

<!-- Why are these changes necessary? -->
**Why**:
I'm creating a select input using downshift (which I really enjoy btw, so big props!), and want it to work similar to the native html5 select input. But in downshift I can't select an item if it's an empty string. I could work around it in my implementation, but to me it seems reasonable for downshift to allow the empty string as a value.

Here's a codesandbox for comparison: 
https://codesandbox.io/s/r0kyyx0y1q

<!-- How were these changes implemented? -->
**How**:
Only escape from selecting a new item if `item == null`.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation "N/A"
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
