### PR TITLE
feat(render): add render prop

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -437,6 +437,15 @@
       "contributions": [
         "infra"
       ]
+    },
+    {
+      "login": "petetnt",
+      "name": "Pete Nykänen",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/7641760?v=4",
+      "profile": "https://twitter.com/pete_tnt",
+      "contributions": [
+        "review"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -7,24 +7,22 @@
 <p align="center" style="font-size: 1.2rem;">Primitives to build simple, flexible, WAI-ARIA compliant React
 autocomplete/dropdown/select/combobox components</p>
 
-> See [the intro blog post](https://blog.kentcdodds.com/introducing-downshift-for-react-b1de3fca0817)
+> See
+> [the intro blog post](https://blog.kentcdodds.com/introducing-downshift-for-react-b1de3fca0817)
 
 <hr />
 
 [![Build Status][build-badge]][build]
 [![Code Coverage][coverage-badge]][coverage]
-[![downloads][downloads-badge]][npmcharts]
-[![version][version-badge]][package]
-[![MIT License][license-badge]][LICENSE]
+[![downloads][downloads-badge]][npmcharts] [![version][version-badge]][package]
+[![MIT License][license-badge]][license]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-45-orange.svg?style=flat-square)](#contributors)
-[![PRs Welcome][prs-badge]][prs]
-[![Chat][chat-badge]][chat]
+[![All Contributors](https://img.shields.io/badge/all_contributors-46-orange.svg?style=flat-square)](#contributors)
+[![PRs Welcome][prs-badge]][prs] [![Chat][chat-badge]][chat]
 [![Code of Conduct][coc-badge]][coc]
 
 [![Supports React and Preact][react-badge]][react]
-[![size][size-badge]][unpkg-dist]
-[![gzip size][gzip-badge]][unpkg-dist]
+[![size][size-badge]][unpkg-dist] [![gzip size][gzip-badge]][unpkg-dist]
 [![module formats: umd, cjs, and es][module-formats-badge]][unpkg-dist]
 
 [![Watch on GitHub][github-watch-badge]][github-watch]
@@ -40,10 +38,10 @@ for your use cases.
 ## This solution
 
 This is a component that controls user interactions and state for you so you can
-create autocomplete/dropdown/select/etc. components. It uses a
-[render function as children][fac] which gives you maximum flexibility with a
-minimal API because you are responsible for the rendering of everything and you
-simply apply props to what you're rendering.
+create autocomplete/dropdown/select/etc. components. It uses a [render
+prop][use-a-render-prop] which gives you maximum flexibility with a minimal API
+because you are responsible for the rendering of everything and you simply apply
+props to what you're rendering.
 
 This differs from other solutions which render things for their use case and
 then expose many options to allow for extensibility resulting in a bigger API
@@ -54,46 +52,47 @@ harder to contribute to.
 > is powerful and flexible enough to build things like dropdowns as well.
 
 ## Table of Contents
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
-- [Installation](#installation)
-- [Usage](#usage)
-- [Props](#props)
-  - [defaultSelectedItem](#defaultselecteditem)
-  - [defaultHighlightedIndex](#defaulthighlightedindex)
-  - [defaultInputValue](#defaultinputvalue)
-  - [defaultIsOpen](#defaultisopen)
-  - [itemToString](#itemtostring)
-  - [selectedItemChanged](#selecteditemchanged)
-  - [getA11yStatusMessage](#geta11ystatusmessage)
-  - [onChange](#onchange)
-  - [onSelect](#onselect)
-  - [onStateChange](#onstatechange)
-  - [onInputValueChange](#oninputvaluechange)
-  - [itemCount](#itemcount)
-  - [highlightedIndex](#highlightedindex)
-  - [inputValue](#inputvalue)
-  - [isOpen](#isopen)
-  - [`selectedItem`](#selecteditem)
-  - [children](#children)
-  - [id](#id)
-  - [environment](#environment)
-  - [onOuterClick](#onouterclick)
-- [Control Props](#control-props)
-- [Child Callback Function](#child-callback-function)
-  - [prop getters](#prop-getters)
-  - [actions](#actions)
-  - [state](#state)
-  - [props](#props)
-- [Examples](#examples)
-- [FAQ](#faq)
-- [Upcoming Breaking Changes](#upcoming-breaking-changes)
-- [Inspiration](#inspiration)
-- [Other Solutions](#other-solutions)
-- [Contributors](#contributors)
-- [LICENSE](#license)
+* [Installation](#installation)
+* [Usage](#usage)
+* [Props](#props)
+  * [defaultSelectedItem](#defaultselecteditem)
+  * [defaultHighlightedIndex](#defaulthighlightedindex)
+  * [defaultInputValue](#defaultinputvalue)
+  * [defaultIsOpen](#defaultisopen)
+  * [itemToString](#itemtostring)
+  * [selectedItemChanged](#selecteditemchanged)
+  * [getA11yStatusMessage](#geta11ystatusmessage)
+  * [onChange](#onchange)
+  * [onSelect](#onselect)
+  * [onStateChange](#onstatechange)
+  * [onInputValueChange](#oninputvaluechange)
+  * [itemCount](#itemcount)
+  * [highlightedIndex](#highlightedindex)
+  * [inputValue](#inputvalue)
+  * [isOpen](#isopen)
+  * [`selectedItem`](#selecteditem)
+  * [render](#render)
+  * [id](#id)
+  * [environment](#environment)
+  * [onOuterClick](#onouterclick)
+* [Control Props](#control-props)
+* [Render Prop Function](#render-prop-function)
+  * [prop getters](#prop-getters)
+  * [actions](#actions)
+  * [state](#state)
+  * [props](#props)
+* [Examples](#examples)
+* [FAQ](#faq)
+* [Upcoming Breaking Changes](#upcoming-breaking-changes)
+* [Inspiration](#inspiration)
+* [Other Solutions](#other-solutions)
+* [Contributors](#contributors)
+* [LICENSE](#license)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -110,8 +109,8 @@ npm install --save downshift
 > have those installed as well.
 
 > Note also this library supports `preact` out of the box. If you are using
-> `preact` then use the corresponding module in the `preact/dist` folder.
-> You can even `import Downshift from 'downshift/preact'` 👍
+> `preact` then use the corresponding module in the `preact/dist` folder. You
+> can even `import Downshift from 'downshift/preact'` 👍
 
 ## Usage
 
@@ -120,14 +119,15 @@ import Downshift from 'downshift'
 
 function BasicAutocomplete({items, onChange}) {
   return (
-    <Downshift onChange={onChange}>
-      {({
+    <Downshift
+      onChange={onChange}
+      render={({
         getInputProps,
         getItemProps,
         isOpen,
         inputValue,
         selectedItem,
-        highlightedIndex
+        highlightedIndex,
       }) => (
         <div>
           <input {...getInputProps({placeholder: 'Favorite color ?'})} />
@@ -156,7 +156,7 @@ function BasicAutocomplete({items, onChange}) {
           ) : null}
         </div>
       )}
-    </Downshift>
+    />
   )
 }
 
@@ -171,8 +171,8 @@ function App() {
 ```
 
 `downshift` is the only component. It doesn't render anything itself, it just
-calls the child function and renders that. Wrap everything in
-`<Downshift>{/* your function here! */}</Downshift>`.
+calls the render function and renders that. ["Use a render
+prop!"][use-a-render-prop]! `<Downshift render={/* your JSX here! */} />`.
 
 ## Props
 
@@ -209,10 +209,11 @@ compute the `inputValue`.
 
 ### selectedItemChanged
 
-> `function(prevItem: any, item: any)` | defaults to: `(prevItem, item) => (prevItem !== item)`
+> `function(prevItem: any, item: any)` | defaults to: `(prevItem, item) =>
+> (prevItem !== item)`
 
-Used to determine if the new `selectedItem` has changed compared to the
-previous `selectedItem` and properly update Downshift's internal state.
+Used to determine if the new `selectedItem` has changed compared to the previous
+`selectedItem` and properly update Downshift's internal state.
 
 ### getA11yStatusMessage
 
@@ -223,9 +224,9 @@ allows you to create your own assertive ARIA statuses.
 
 A default `getA11yStatusMessage` function is provided that will check
 `resultCount` and return "No results." or if there are results but no item is
-highlighted, "`resultCount` results are available, use up and down arrow keys
-to navigate."  If an item is highlighted it will run
-`itemToString(highlightedItem)` and display the value of the `highlightedItem`.
+highlighted, "`resultCount` results are available, use up and down arrow keys to
+navigate." If an item is highlighted it will run `itemToString(highlightedItem)`
+and display the value of the `highlightedItem`.
 
 The object you are passed to generate your status message has the following
 properties:
@@ -233,7 +234,7 @@ properties:
 <!-- This table was generated via http://www.tablesgenerator.com/markdown_tables -->
 
 | property              | type            | description                                                                                  |
-|-----------------------|-----------------|----------------------------------------------------------------------------------------------|
+| --------------------- | --------------- | -------------------------------------------------------------------------------------------- |
 | `highlightedIndex`    | `number`/`null` | The currently highlighted index                                                              |
 | `highlightedValue`    | `any`           | The value of the highlighted item                                                            |
 | `inputValue`          | `string`        | The current input value                                                                      |
@@ -245,138 +246,151 @@ properties:
 
 ### onChange
 
-> `function(selectedItem: any, stateAndHelpers: object)` | optional, no useful default
+> `function(selectedItem: any, stateAndHelpers: object)` | optional, no useful
+> default
 
-Called when the user selects an item and the selected item has changed. Called with the item that was selected
-and the new state of `downshift`. (see `onStateChange` for more info on
-`stateAndHelpers`).
+Called when the user selects an item and the selected item has changed. Called
+with the item that was selected and the new state of `downshift`. (see
+`onStateChange` for more info on `stateAndHelpers`).
 
-- `selectedItem`: The item that was just selected
-- `stateAndHelpers`: This is the same thing your `children` prop
-  function is called with (see [Child Callback Function](#child-callback-function))
+* `selectedItem`: The item that was just selected
+* `stateAndHelpers`: This is the same thing your `render` prop function is
+  called with (see [Render Prop Function](#render-prop-function))
 
 ### onSelect
 
-> `function(selectedItem: any, stateAndHelpers: object)` | optional, no useful default
+> `function(selectedItem: any, stateAndHelpers: object)` | optional, no useful
+> default
 
 Called when the user selects an item, regardless of the previous selected item.
- Called with the item that was selected
-and the new state of `downshift`. (see `onStateChange` for more info on
-`stateAndHelpers`).
+Called with the item that was selected and the new state of `downshift`. (see
+`onStateChange` for more info on `stateAndHelpers`).
 
-- `selectedItem`: The item that was just selected
-- `stateAndHelpers`: This is the same thing your `children` prop
-  function is called with (see [Child Callback Function](#child-callback-function))
+* `selectedItem`: The item that was just selected
+* `stateAndHelpers`: This is the same thing your `render` prop function is
+  called with (see [Render Prop Function](#render-prop-function))
 
 ### onStateChange
 
-> `function(changes: object, stateAndHelpers: object)` | optional, no useful default
+> `function(changes: object, stateAndHelpers: object)` | optional, no useful
+> default
 
 This function is called anytime the internal state changes. This can be useful
 if you're using downshift as a "controlled" component, where you manage some or
 all of the state (e.g. isOpen, selectedItem, highlightedIndex, etc) and then
 pass it as props, rather than letting downshift control all its state itself.
-The parameters both take the shape of internal state
-(`{highlightedIndex: number, inputValue: string, isOpen: boolean, selectedItem: any}`)
-but differ slightly.
+The parameters both take the shape of internal state (`{highlightedIndex:
+number, inputValue: string, isOpen: boolean, selectedItem: any}`) but differ
+slightly.
 
-- `changes`: These are the properties that actually have changed since the last
+* `changes`: These are the properties that actually have changed since the last
   state change.
-- `stateAndHelpers`: This is the exact same thing your `children` prop
-  function is called with (see [Child Callback Function](#child-callback-function))
+* `stateAndHelpers`: This is the exact same thing your `render` prop function is
+  called with (see [Render Prop Function](#render-prop-function))
 
 > Tip: This function will be called any time _any_ state is changed. The best
 > way to determine whether any particular state was changed, you can use
 > `changes.hasOwnProperty('propName')`.
 
 > Note: the `changes` object will also have a `type` property that corresponds
-> to a `Downshift.stateChangeTypes` property. This is an experimental feature
-> so it's not recommended to use it if you can avoid it. If you need it, please
+> to a `Downshift.stateChangeTypes` property. This is an experimental feature so
+> it's not recommended to use it if you can avoid it. If you need it, please
 > open an issue to discuss solidifying the API.
 
 ### onInputValueChange
 
-> `function(inputValue: string, stateAndHelpers: object)` | optional, no useful default
+> `function(inputValue: string, stateAndHelpers: object)` | optional, no useful
+> default
 
-Called whenever the input value changes. Useful to use instead or in combination of `onStateChange` when `inputValue` is a controlled prop to [avoid issues with cursor positions](https://github.com/paypal/downshift/issues/217).
+Called whenever the input value changes. Useful to use instead or in combination
+of `onStateChange` when `inputValue` is a controlled prop to
+[avoid issues with cursor positions](https://github.com/paypal/downshift/issues/217).
 
-- `inputValue`: The current value of the input
-- `stateAndHelpers`: This is the same thing your `children` prop
-  function is called with (see [Child Callback Function](#child-callback-function))
+* `inputValue`: The current value of the input
+* `stateAndHelpers`: This is the same thing your `render` prop function is
+  called with (see [Render Prop Function](#render-prop-function))
 
 ### itemCount
 
 > `number` | optional, defaults the number of times you call getItemProps
 
 This is useful if you're using some kind of virtual listing component for
-"windowing" (like [`react-virtualized`](https://github.com/bvaughn/react-virtualized)).
+"windowing" (like
+[`react-virtualized`](https://github.com/bvaughn/react-virtualized)).
 
 ### highlightedIndex
 
-> `number` | **control prop** (read more about this in the "Control Props" section below)
+> `number` | **control prop** (read more about this in the "Control Props"
+> section below)
 
 The index that should be highlighted
 
 ### inputValue
 
-> `string` | **control prop** (read more about this in the "Control Props" section below)
+> `string` | **control prop** (read more about this in the "Control Props"
+> section below)
 
 The value the input should have
 
 ### isOpen
 
-> `boolean` | **control prop** (read more about this in the "Control Props" section below)
+> `boolean` | **control prop** (read more about this in the "Control Props"
+> section below)
 
 Whether the menu should be considered open or closed. Some aspects of the
 downshift component respond differently based on this value (for example, if
-`isOpen` is true when the user hits "Enter" on the input field, then the
-item at the `highlightedIndex` item is selected).
+`isOpen` is true when the user hits "Enter" on the input field, then the item at
+the `highlightedIndex` item is selected).
 
 ### `selectedItem`
 
-> `any`/`Array(any)` | **control prop** (read more about this in the "Control Props" section below)
+> `any`/`Array(any)` | **control prop** (read more about this in the "Control
+> Props" section below)
 
 The currently selected item.
 
-### children
+### render
 
-> `function({})` | *required*
+> `function({})` | _required_
 
-This is called with an object. Read more about the properties of this object
-in the section "Child Callback Function"
+This is called with an object. Read more about the properties of this object in
+the section "[Render Prop Function](#render-prop-function)".
 
 ### id
 
 > `string` | defaults to a generated ID
 
-You should not normally need to set this prop. It's only useful if you're
-server rendering items (which each have an `id` prop generated based on the
-`downshift` `id`). For more information see the `FAQ` below.
+You should not normally need to set this prop. It's only useful if you're server
+rendering items (which each have an `id` prop generated based on the `downshift`
+`id`). For more information see the `FAQ` below.
 
 ### environment
 
 > `window` | defaults to `window`
 
 You should not normally need to set this prop. It's only useful if you're
- rendering into a different `window` context from where your JavaScript is running, for example an iframe.
-
+rendering into a different `window` context from where your JavaScript is
+running, for example an iframe.
 
 ### onOuterClick
 
 > `function` | optional
 
-A helper callback to help control internal state of downshift like `isOpen` as mentioned in
-[this issue](https://github.com/paypal/downshift/issues/206). The same behavior can be achieved
-using `onStateChange`, but this prop is provided as a helper because it's a fairly common
-use-case if you're controlling the `isOpen` state:
+A helper callback to help control internal state of downshift like `isOpen` as
+mentioned in [this issue](https://github.com/paypal/downshift/issues/206). The
+same behavior can be achieved using `onStateChange`, but this prop is provided
+as a helper because it's a fairly common use-case if you're controlling the
+`isOpen` state:
 
 ```jsx
-<Downshift
-  isOpen={this.state.menuIsOpen}
-  onOuterClick={() => this.setState({menuIsOpen: false})}
->
-  {/* your callback */}
-</Downshift>
+const ui = (
+  <Downshift
+    isOpen={this.state.menuIsOpen}
+    onOuterClick={() => this.setState({menuIsOpen: false})}
+  >
+    {/* your callback */}
+  </Downshift>
+)
 ```
 
 ## Control Props
@@ -384,8 +398,8 @@ use-case if you're controlling the `isOpen` state:
 downshift manages its own state internally and calls your `onChange` and
 `onStateChange` handlers with any relevant changes. The state that downshift
 manages includes: `isOpen`, `selectedItem`, `inputValue`, and
-`highlightedIndex`. Your child callback function (read more below) can be used
-to manipulate this state from within the render function and can likely support
+`highlightedIndex`. Your render prop function (read more below) can be used to
+manipulate this state from within the render function and can likely support
 many of your use cases.
 
 However, if more control is needed, you can pass any of these pieces of state as
@@ -398,40 +412,42 @@ that state from other components, `redux`, `react-router`, or anywhere else.
 
 > Note: This is very similar to how normal controlled components work elsewhere
 > in react (like `<input />`). If you want to learn more about this concept, you
-> can learn about that from this the
-> ["Controlled Components" lecture][controlled-components-lecture] and
-> exercises from [React Training's][react-training]
-> [Advanced React][advanced-react] course.
+> can learn about that from this the ["Controlled Components"
+> lecture][controlled-components-lecture] and exercises from [React
+> Training's][react-training] > [Advanced React][advanced-react] course.
 
-## Child Callback Function
+## Render Prop Function
 
 This is where you render whatever you want to based on the state of `downshift`.
-The function is passed as the child prop:
-`<Downshift>{/* right here*/}</Downshift>`
+It's a regular prop called `render`: `<Downshift render={/* right here*/} />`.
+
+> You can also pass it as the children prop if you prefer to do things that way
+> `<Downshift>{/* right here*/}</Downshift>`
 
 The properties of this object can be split into three categories as indicated
 below:
 
 ### prop getters
 
-> See [the blog post about prop getters](https://blog.kentcdodds.com/how-to-give-rendering-control-to-users-with-prop-getters-549eaef76acf)
+> See
+> [the blog post about prop getters](https://blog.kentcdodds.com/how-to-give-rendering-control-to-users-with-prop-getters-549eaef76acf)
 
-These functions are used to apply props to the elements that you render.
-This gives you maximum flexibility to render what, when, and wherever you like.
-You call these on the element in question (for example:
-`<input {...getInputProps()}`)). It's advisable to pass all your props to that
-function rather than applying them on the element yourself to avoid your props
-being overridden (or overriding the props returned). For example:
+These functions are used to apply props to the elements that you render. This
+gives you maximum flexibility to render what, when, and wherever you like. You
+call these on the element in question (for example: `<input
+{...getInputProps()}`)). It's advisable to pass all your props to that function
+rather than applying them on the element yourself to avoid your props being
+overridden (or overriding the props returned). For example:
 `getInputProps({onKeyUp(event) {console.log(event)}})`.
 
 <!-- This table was generated via http://www.tablesgenerator.com/markdown_tables -->
 
-| property         | type           | description                                                                                 |
-|------------------|----------------|---------------------------------------------------------------------------------------------|
-| `getButtonProps` | `function({})` | returns the props you should apply to any menu toggle button element you render.            |
-| `getInputProps`  | `function({})` | returns the props you should apply to the `input` element that you render.                  |
-| `getItemProps`   | `function({})` | returns the props you should apply to any menu item elements you render.                    |
-| `getLabelProps`  | `function({})` | returns the props you should apply to the `label` element that you render.                  |
+| property         | type              | description                                                                                 |
+| ---------------- | ----------------- | ------------------------------------------------------------------------------------------- |
+| `getButtonProps` | `function({})`    | returns the props you should apply to any menu toggle button element you render.            |
+| `getInputProps`  | `function({})`    | returns the props you should apply to the `input` element that you render.                  |
+| `getItemProps`   | `function({})`    | returns the props you should apply to any menu item elements you render.                    |
+| `getLabelProps`  | `function({})`    | returns the props you should apply to the `label` element that you render.                  |
 | `getRootProps`   | `function({},{})` | returns the props you should apply to the root element that you render. It can be optional. |
 
 #### `getRootProps`
@@ -444,29 +460,27 @@ your root element.
 
 Required properties:
 
-- `refKey`: if you're rendering a composite component, that component will need
+* `refKey`: if you're rendering a composite component, that component will need
   to accept a prop which it forwards to the root DOM element. Commonly, folks
-  call this `innerRef`. So you'd call: `getRootProps({refKey: 'innerRef'})`
-  and your composite component would forward like:
-  `<div ref={props.innerRef} />`
+  call this `innerRef`. So you'd call: `getRootProps({refKey: 'innerRef'})` and
+  your composite component would forward like: `<div ref={props.innerRef} />`
 
 If you're rendering a composite component, `Downshift` checks that
 `getRootProps` is called and that `refKey` is a prop of the returned composite
-component.
-This is done to catch common causes of errors but, in some cases, the check
-could fail even if the ref is correctly forwarded to the root DOM component.
-In these cases, you can provide the object `{suppressRefError : true}` as the
-second argument to `getRootProps` to completely bypass the check.  
-**Please use it with extreme care and only if you are absolutely sure that the
-ref is correctly forwarded otherwise `Downshift` will unexpectedly fail.**  
+component. This is done to catch common causes of errors but, in some cases, the
+check could fail even if the ref is correctly forwarded to the root DOM
+component. In these cases, you can provide the object `{suppressRefError :
+true}` as the second argument to `getRootProps` to completely bypass the check.\
+**Please use it with extreme care and only if you are absolutely sure that the ref
+is correctly forwarded otherwise `Downshift` will unexpectedly fail.**\
 See issue paypal/downshift#235 for the discussion that lead to this.
 
 #### `getInputProps`
 
 This method should be applied to the `input` you render. It is recommended that
 you pass all props as an object to this method which will compose together any
-of the event handlers you need to apply to the `input` while preserving the
-ones that `downshift` needs to apply to make the `input` behave.
+of the event handlers you need to apply to the `input` while preserving the ones
+that `downshift` needs to apply to make the `input` behave.
 
 There are no required properties for this method.
 
@@ -512,21 +526,19 @@ items.map(item => {
 Instead, you could do this:
 
 ```jsx
-items
-  .filter(shouldRenderItem)
-  .map(item => <div {...getItemProps({item})} />)
+items.filter(shouldRenderItem).map(item => <div {...getItemProps({item})} />)
 ```
 
 </details>
 
 Required properties:
 
-- `item`: this is the item data that will be selected when the user selects a
+* `item`: this is the item data that will be selected when the user selects a
   particular item.
 
 Optional properties:
 
-- `index`: this is how `downshift` keeps track of your item when updating the
+* `index`: this is how `downshift` keeps track of your item when updating the
   `highlightedIndex` as the user keys around. By default, `downshift` will
   assume the `index` is the order in which you're calling `getItemProps`. This
   is often good enough, but if you find odd behavior, try setting this
@@ -536,16 +548,19 @@ Optional properties:
 #### `getButtonProps`
 
 Call this and apply the returned props to a `button`. It allows you to toggle
-the `Menu` component. You can definitely build something like this yourself
-(all of the available APIs are exposed to you), but this is nice because it
-will also apply all of the proper ARIA attributes. The `aria-label` prop is in
-English. You should probably override this yourself so you can provide
-translations:
+the `Menu` component. You can definitely build something like this yourself (all
+of the available APIs are exposed to you), but this is nice because it will also
+apply all of the proper ARIA attributes. The `aria-label` prop is in English.
+You should probably override this yourself so you can provide translations:
 
 ```jsx
-<button {...getButtonProps({
-  'aria-label': translateWithId(isOpen ? 'close.menu' : 'open.menu'),
-})} />
+const myButton = (
+  <button
+    {...getButtonProps({
+      'aria-label': translateWithId(isOpen ? 'close.menu' : 'open.menu'),
+    })}
+  />
+)
 ```
 
 ### actions
@@ -554,18 +569,18 @@ These are functions you can call to change the state of the downshift component.
 
 <!-- This table was generated via http://www.tablesgenerator.com/markdown_tables -->
 
-| property                | type                                                             | description                                                                  |
-|-------------------------|------------------------------------------------------------------|------------------------------------------------------------------------------|
-| `clearSelection`        | `function(cb: Function)`                                         | clears the selection                                                         |
-| `clearItems`            | `function()`                                                     | Clears downshift's record of all the items. Only really useful if you render your items asynchronously within downshift. See [#186](https://github.com/paypal/downshift/issues/186)                                                             |
-| `closeMenu`             | `function(cb: Function)`                                         | closes the menu                                                              |
-| `openMenu`              | `function(cb: Function)`                                         | opens the menu                                                               |
-| `selectHighlightedItem` | `function(otherStateToSet: object, cb: Function)`                | selects the item that is currently highlighted                               |
-| `selectItem`            | `function(item: any, otherStateToSet: object, cb: Function)`     | selects the given item                                                       |
-| `selectItemAtIndex`     | `function(index: number, otherStateToSet: object, cb: Function)` | selects the item at the given index                                          |
-| `setHighlightedIndex`   | `function(index: number, otherStateToSet: object, cb: Function)` | call to set a new highlighted index                                          |
-| `toggleMenu`            | `function(otherStateToSet: object, cb: Function)`                | toggle the menu open state                                                   |
-| `reset`                 | `function(otherStateToSet: object, cb: Function)`                | this resets downshift's state to a reasonable default                        |
+| property                | type                                                             | description                                                                                                                                                                         |
+| ----------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `clearSelection`        | `function(cb: Function)`                                         | clears the selection                                                                                                                                                                |
+| `clearItems`            | `function()`                                                     | Clears downshift's record of all the items. Only really useful if you render your items asynchronously within downshift. See [#186](https://github.com/paypal/downshift/issues/186) |
+| `closeMenu`             | `function(cb: Function)`                                         | closes the menu                                                                                                                                                                     |
+| `openMenu`              | `function(cb: Function)`                                         | opens the menu                                                                                                                                                                      |
+| `selectHighlightedItem` | `function(otherStateToSet: object, cb: Function)`                | selects the item that is currently highlighted                                                                                                                                      |
+| `selectItem`            | `function(item: any, otherStateToSet: object, cb: Function)`     | selects the given item                                                                                                                                                              |
+| `selectItemAtIndex`     | `function(index: number, otherStateToSet: object, cb: Function)` | selects the item at the given index                                                                                                                                                 |
+| `setHighlightedIndex`   | `function(index: number, otherStateToSet: object, cb: Function)` | call to set a new highlighted index                                                                                                                                                 |
+| `toggleMenu`            | `function(otherStateToSet: object, cb: Function)`                | toggle the menu open state                                                                                                                                                          |
+| `reset`                 | `function(otherStateToSet: object, cb: Function)`                | this resets downshift's state to a reasonable default                                                                                                                               |
 
 > `otherStateToSet` refers to an object to set other internal state. It is
 > recommended to avoid abusing this, but is available if you need it.
@@ -577,7 +592,7 @@ These are values that represent the current state of the downshift component.
 <!-- This table was generated via http://www.tablesgenerator.com/markdown_tables -->
 
 | property           | type              | description                                    |
-|--------------------|-------------------|------------------------------------------------|
+| ------------------ | ----------------- | ---------------------------------------------- |
 | `highlightedIndex` | `number` / `null` | the currently highlighted item                 |
 | `inputValue`       | `string` / `null` | the current value of the `getInputProps` input |
 | `isOpen`           | `boolean`         | the menu open state                            |
@@ -585,40 +600,48 @@ These are values that represent the current state of the downshift component.
 
 ### props
 
-As a convenience, the `id` and `itemToString` props which you pass to `<Downshift />` are available here as well.
+As a convenience, the `id` and `itemToString` props which you pass to
+`<Downshift />` are available here as well.
 
 ## Examples
 
 Examples exist on [codesandbox.io][examples]:
 
-- [Bare bones autocomplete](https://codesandbox.io/s/6z67jvklw3)
-- [Multiple selection](https://codesandbox.io/s/W6gyJ30kn) (uses controlled `selectedItem` API).
-- [Type Ahead Example](https://codesandbox.io/s/82m2px40q9) (uses controlled `selectedItem` API).
-- [Integration with Apollo](https://codesandbox.io/s/m5zrvqj85p)
-- [Integration with Redux](https://codesandbox.io/s/3ywmnyr0zq)
-- [Integration with `react-instantsearch`](https://codesandbox.io/s/kvn0lpp83) from Algolia
-- [Material UI (1.0.0-beta.4) Combobox Using Downshift](https://codesandbox.io/s/QMGq4kAY)
-- [Integration with `GenieJS`](https://codesandbox.io/s/jRLKrxwgl) ([learn more about `genie` here](https://github.com/kentcdodds/genie))
-- [Handling and displaying errors](https://codesandbox.io/s/zKE37vorr)
-- [Integration with React Router](https://codesandbox.io/s/ww9lwloy8w)
-- [Windowing with `react-tiny-virtual-list`](https://codesandbox.io/s/v670kq95l)
-- [Section/option group example](https://codesandbox.io/s/zx1kj58npl)
-- [Integration with `fuzzaldrin-plus` (Fuzzy matching)](https://codesandbox.io/s/pyq3v4o3j)
-- [Dropdown/select implementation with Bootstrap](https://codesandbox.io/s/53y8jvpj0k)
-- [Multiple editable tag selection](https://codesandbox.io/s/o4yp9vmm8z)
-- [Downshift implemented as compound components and a Higher Order Component](https://codesandbox.io/s/017n1jqo00) (exposes a `withDownshift` higher order component which you can use to get at the state, actions, prop getters in a rendered downshift tree).
-- [Downshift Spectre.css example](https://codesandbox.io/s/M89KQOBRB)
+* [Bare bones autocomplete](https://codesandbox.io/s/6z67jvklw3)
+* [Multiple selection](https://codesandbox.io/s/W6gyJ30kn) (uses controlled
+  `selectedItem` API).
+* [Type Ahead Example](https://codesandbox.io/s/82m2px40q9) (uses controlled
+  `selectedItem` API).
+* [Integration with Apollo](https://codesandbox.io/s/m5zrvqj85p)
+* [Integration with Redux](https://codesandbox.io/s/3ywmnyr0zq)
+* [Integration with `react-instantsearch`](https://codesandbox.io/s/kvn0lpp83)
+  from Algolia
+* [Material UI (1.0.0-beta.4) Combobox Using Downshift](https://codesandbox.io/s/QMGq4kAY)
+* [Integration with `GenieJS`](https://codesandbox.io/s/jRLKrxwgl)
+  ([learn more about `genie` here](https://github.com/kentcdodds/genie))
+* [Handling and displaying errors](https://codesandbox.io/s/zKE37vorr)
+* [Integration with React Router](https://codesandbox.io/s/ww9lwloy8w)
+* [Windowing with `react-tiny-virtual-list`](https://codesandbox.io/s/v670kq95l)
+* [Section/option group example](https://codesandbox.io/s/zx1kj58npl)
+* [Integration with `fuzzaldrin-plus` (Fuzzy matching)](https://codesandbox.io/s/pyq3v4o3j)
+* [Dropdown/select implementation with Bootstrap](https://codesandbox.io/s/53y8jvpj0k)
+* [Multiple editable tag selection](https://codesandbox.io/s/o4yp9vmm8z)
+* [Downshift implemented as compound components and a Higher Order Component](https://codesandbox.io/s/017n1jqo00)
+  (exposes a `withDownshift` higher order component which you can use to get at
+  the state, actions, prop getters in a rendered downshift tree).
+* [Downshift Spectre.css example](https://codesandbox.io/s/M89KQOBRB)
 
 If you would like to add an example, follow these steps:
 
 1. Fork [this codesandbox](http://kcd.im/ds-example)
 2. Make sure your version (under dependencies) is the latest available version.
 3. Update the title and description
-4. Update the code for your example (add some form of documentation to explain what it is)
+4. Update the code for your example (add some form of documentation to explain
+   what it is)
 5. Add the tag: `downshift:example`
 
-You'll find other examples in the `stories/examples` folder of the repo.
-And you'll find
+You'll find other examples in the `stories/examples` folder of the repo. And
+you'll find
 [a live version of those examples here](https://downshift.netlify.com)
 
 ## FAQ
@@ -631,22 +654,27 @@ The checksum error you're seeing is most likely due to the automatically
 generated `id` and/or `htmlFor` prop you get from `getInputProps` and
 `getLabelProps` (respectively). It could also be from the automatically
 generated `id` prop you get from `getItemProps` (though this is not likely as
-you're probably not rendering any items when rendering a downshift component
-on the server).
+you're probably not rendering any items when rendering a downshift component on
+the server).
 
 To avoid these problems, simply provide your own `id` prop in `getInputProps`
 and `getLabelProps`. Also, you can use the `id` prop on the component
 `Downshift`. For example:
 
 ```javascript
-<Downshift id="autocomplete">
-  {({getInputProps, getLabelProps}) => (
-    <label {...getLabelProps({htmlFor: 'autocomplete-input'})}>
-      Some Label
-    </label>
-    <input {...getInputProps({id: 'autocomplete-input'})} />
-  )}
-</Downshift>
+const ui = (
+  <Downshift
+    id="autocomplete"
+    render={({getInputProps, getLabelProps}) => (
+      <div>
+        <label {...getLabelProps({htmlFor: 'autocomplete-input'})}>
+          Some Label
+        </label>
+        <input {...getInputProps({id: 'autocomplete-input'})} />
+      </div>
+    )}
+  />
+)
 ```
 
 </details>
@@ -654,20 +682,28 @@ and `getLabelProps`. Also, you can use the `id` prop on the component
 ## Upcoming Breaking Changes
 
 We try to avoid breaking changes when possible and try to adhere to
-[semver][semver]. Sometimes breaking changes are necessary and we'll make
-the transition as smooth as possible. This is why there's a prop available
-which will allow you to opt into breaking changes. It looks like this:
+[semver][semver]. Sometimes breaking changes are necessary and we'll make the
+transition as smooth as possible. This is why there's a prop available which
+will allow you to opt into breaking changes. It looks like this:
 
 ```javascript
-<Downshift breakingChanges={{ /* breaking change flags here */ }}>
-  /* your render function here */
-</Downshift>
+const ui = (
+  <Downshift
+    breakingChanges={
+      {
+        /* breaking change flags here */
+      }
+    }
+    render={() => <div />}
+  />
+)
 ```
 
 To opt-into a breaking change, simply provide the key and value in the
 `breakingChanges` object prop for each breaking change mentioned below:
 
-1. `resetInputOnSelection` - Enable with the value of `true`. For more information, see [#243](https://github.com/paypal/downshift/issues/243)
+1. `resetInputOnSelection` - Enable with the value of `true`. For more
+   information, see [#243](https://github.com/paypal/downshift/issues/243)
 
 When a new major version is released, then the code to support the old
 functionality will be removed and the breaking change version will be the
@@ -676,37 +712,38 @@ default, so it's suggested you enable these as soon as you are aware of them.
 ## Inspiration
 
 I was heavily inspired by [Ryan Florence][ryan]. Watch his (free) lesson about
-["Compound Components"][compound-components-lecture]. Initially downshift was
-a group of compound components using context to communicate. But then
-[Jared Forsyth][jared] suggested I expose functions (the prop getters) to get
-props to apply to the elements rendered. That bit of inspiration made a big
-impact on the flexibility and simplicity of this API.
+["Compound Components"][compound-components-lecture]. Initially downshift was a
+group of compound components using context to communicate. But then [Jared
+Forsyth][jared] suggested I expose functions (the prop getters) to get props to
+apply to the elements rendered. That bit of inspiration made a big impact on the
+flexibility and simplicity of this API.
 
 I also took a few ideas from the code in
-[`react-autocomplete`][react-autocomplete] and
-[jQuery UI's Autocomplete][jquery-complete].
+[`react-autocomplete`][react-autocomplete] and [jQuery UI's
+Autocomplete][jquery-complete].
 
 You can watch me build the first iteration of `downshift` on YouTube:
 
-- [Part 1](https://www.youtube.com/watch?v=2kzD1IjDy5s&list=PLV5CVI1eNcJh5CTgArGVwANebCrAh2OUE&index=11)
-- [Part 2](https://www.youtube.com/watch?v=w1Z7Jvj08_s&list=PLV5CVI1eNcJh5CTgArGVwANebCrAh2OUE&index=10)
+* [Part 1](https://www.youtube.com/watch?v=2kzD1IjDy5s&list=PLV5CVI1eNcJh5CTgArGVwANebCrAh2OUE&index=11)
+* [Part 2](https://www.youtube.com/watch?v=w1Z7Jvj08_s&list=PLV5CVI1eNcJh5CTgArGVwANebCrAh2OUE&index=10)
 
-You'll find more recordings of me working on `downshift` on
-[my livestream YouTube playlist][yt-playlist].
+You'll find more recordings of me working on `downshift` on [my livestream
+YouTube playlist][yt-playlist].
 
 ## Other Solutions
 
-You can implement these other solutions using `downshift`, but if
-you'd prefer to use these out of the box solutions, then that's fine too:
+You can implement these other solutions using `downshift`, but if you'd prefer
+to use these out of the box solutions, then that's fine too:
 
-- [`react-select`](https://github.com/JedWatson/react-select)
-- [`react-autocomplete`](https://github.com/reactjs/react-autocomplete)
+* [`react-select`](https://github.com/JedWatson/react-select)
+* [`react-autocomplete`](https://github.com/reactjs/react-autocomplete)
 
 ## Contributors
 
 Thanks goes to these people ([emoji key][emojis]):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+
 <!-- prettier-ignore -->
 | [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub><b>Kent C. Dodds</b></sub>](https://kentcdodds.com)<br />[💻](https://github.com/paypal/downshift/commits?author=kentcdodds "Code") [📖](https://github.com/paypal/downshift/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/paypal/downshift/commits?author=kentcdodds "Tests") | [<img src="https://avatars0.githubusercontent.com/u/100200?v=4" width="100px;"/><br /><sub><b>Ryan Florence</b></sub>](http://twitter.com/ryanflorence)<br />[🤔](#ideas-ryanflorence "Ideas, Planning, & Feedback") | [<img src="https://avatars3.githubusercontent.com/u/112170?v=4" width="100px;"/><br /><sub><b>Jared Forsyth</b></sub>](http://jaredforsyth.com)<br />[🤔](#ideas-jaredly "Ideas, Planning, & Feedback") [📖](https://github.com/paypal/downshift/commits?author=jaredly "Documentation") | [<img src="https://avatars1.githubusercontent.com/u/8162598?v=4" width="100px;"/><br /><sub><b>Jack Moore</b></sub>](https://github.com/jtmthf)<br />[💡](#example-jtmthf "Examples") | [<img src="https://avatars1.githubusercontent.com/u/2762082?v=4" width="100px;"/><br /><sub><b>Travis Arnold</b></sub>](http://travisrayarnold.com)<br />[💻](https://github.com/paypal/downshift/commits?author=souporserious "Code") [📖](https://github.com/paypal/downshift/commits?author=souporserious "Documentation") | [<img src="https://avatars0.githubusercontent.com/u/1045233?v=4" width="100px;"/><br /><sub><b>Marcy Sutton</b></sub>](http://marcysutton.com)<br />[🐛](https://github.com/paypal/downshift/issues?q=author%3Amarcysutton "Bug reports") [🤔](#ideas-marcysutton "Ideas, Planning, & Feedback") | [<img src="https://avatars2.githubusercontent.com/u/244704?v=4" width="100px;"/><br /><sub><b>Jeremy Gayed</b></sub>](http://www.jeremygayed.com)<br />[💡](#example-tizmagik "Examples") |
 | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
@@ -715,7 +752,8 @@ Thanks goes to these people ([emoji key][emojis]):
 | [<img src="https://avatars0.githubusercontent.com/u/1402095?v=4" width="100px;"/><br /><sub><b>Matt Parrish</b></sub>](https://github.com/pbomb)<br />[🔧](#tool-pbomb "Tools") [👀](#review-pbomb "Reviewed Pull Requests") | [<img src="https://avatars1.githubusercontent.com/u/11661846?v=4" width="100px;"/><br /><sub><b>thom</b></sub>](http://thom.kr)<br />[💻](https://github.com/paypal/downshift/commits?author=thomhos "Code") | [<img src="https://avatars2.githubusercontent.com/u/1088312?v=4" width="100px;"/><br /><sub><b>Vu Tran</b></sub>](http://twitter.com/tranvu)<br />[💻](https://github.com/paypal/downshift/commits?author=vutran "Code") | [<img src="https://avatars1.githubusercontent.com/u/74193?v=4" width="100px;"/><br /><sub><b>Codie Mullins</b></sub>](https://github.com/codiemullins)<br />[💻](https://github.com/paypal/downshift/commits?author=codiemullins "Code") [💡](#example-codiemullins "Examples") | [<img src="https://avatars3.githubusercontent.com/u/12202757?v=4" width="100px;"/><br /><sub><b>Mohammad Rajabifard</b></sub>](https://morajabi.me)<br />[📖](https://github.com/paypal/downshift/commits?author=morajabi "Documentation") [🤔](#ideas-morajabi "Ideas, Planning, & Feedback") | [<img src="https://avatars3.githubusercontent.com/u/9488719?v=4" width="100px;"/><br /><sub><b>Frank Tan</b></sub>](https://github.com/tansongyang)<br />[💻](https://github.com/paypal/downshift/commits?author=tansongyang "Code") | [<img src="https://avatars3.githubusercontent.com/u/5093058?v=4" width="100px;"/><br /><sub><b>Kier Borromeo</b></sub>](https://kierb.com)<br />[💡](#example-srph "Examples") |
 | [<img src="https://avatars1.githubusercontent.com/u/8969456?v=4" width="100px;"/><br /><sub><b>Paul Veevers</b></sub>](https://github.com/paul-veevers)<br />[💻](https://github.com/paypal/downshift/commits?author=paul-veevers "Code") | [<img src="https://avatars2.githubusercontent.com/u/13622298?v=4" width="100px;"/><br /><sub><b>Ron Cruz</b></sub>](https://github.com/Ronolibert)<br />[📖](https://github.com/paypal/downshift/commits?author=Ronolibert "Documentation") | [<img src="https://avatars1.githubusercontent.com/u/13605633?v=4" width="100px;"/><br /><sub><b>Rick McGavin</b></sub>](http://rickmcgavin.github.io)<br />[📖](https://github.com/paypal/downshift/commits?author=rickMcGavin "Documentation") | [<img src="https://avatars0.githubusercontent.com/u/869669?v=4" width="100px;"/><br /><sub><b>Jelle Versele</b></sub>](http://twitter.com/vejersele)<br />[💡](#example-vejersele "Examples") | [<img src="https://avatars1.githubusercontent.com/u/202773?v=4" width="100px;"/><br /><sub><b>Brent Ertz</b></sub>](https://github.com/brentertz)<br />[🤔](#ideas-brentertz "Ideas, Planning, & Feedback") | [<img src="https://avatars3.githubusercontent.com/u/8015514?v=4" width="100px;"/><br /><sub><b>Justice Mba </b></sub>](https://github.com/Dajust)<br />[💻](https://github.com/paypal/downshift/commits?author=Dajust "Code") [📖](https://github.com/paypal/downshift/commits?author=Dajust "Documentation") [🤔](#ideas-Dajust "Ideas, Planning, & Feedback") | [<img src="https://avatars2.githubusercontent.com/u/3925281?v=4" width="100px;"/><br /><sub><b>Mark Ellis</b></sub>](http://mfellis.com)<br />[🤔](#ideas-ellismarkf "Ideas, Planning, & Feedback") |
 | [<img src="https://avatars1.githubusercontent.com/u/3241922?v=4" width="100px;"/><br /><sub><b>us͡an̸df͘rien͜ds͠</b></sub>](http://ronak.io/)<br />[🐛](https://github.com/paypal/downshift/issues?q=author%3Ausandfriends "Bug reports") [💻](https://github.com/paypal/downshift/commits?author=usandfriends "Code") [⚠️](https://github.com/paypal/downshift/commits?author=usandfriends "Tests") | [<img src="https://avatars0.githubusercontent.com/u/474248?v=4" width="100px;"/><br /><sub><b>Robin Drexler</b></sub>](https://www.robin-drexler.com/)<br />[🐛](https://github.com/paypal/downshift/issues?q=author%3Arobin-drexler "Bug reports") [💻](https://github.com/paypal/downshift/commits?author=robin-drexler "Code") | [<img src="https://avatars0.githubusercontent.com/u/7406639?v=4" width="100px;"/><br /><sub><b>Arturo Romero</b></sub>](http://arturoromero.info/)<br />[💡](#example-arturoromeroslc "Examples") | [<img src="https://avatars1.githubusercontent.com/u/275483?v=4" width="100px;"/><br /><sub><b>yp</b></sub>](http://algolab.eu/pirola)<br />[🐛](https://github.com/paypal/downshift/issues?q=author%3Ayp "Bug reports") [💻](https://github.com/paypal/downshift/commits?author=yp "Code") [⚠️](https://github.com/paypal/downshift/commits?author=yp "Tests") | [<img src="https://avatars0.githubusercontent.com/u/3998604?v=4" width="100px;"/><br /><sub><b>Dave Garwacke</b></sub>](http://www.warbyparker.com)<br />[📖](https://github.com/paypal/downshift/commits?author=ifyoumakeit "Documentation") | [<img src="https://avatars3.githubusercontent.com/u/11758660?v=4" width="100px;"/><br /><sub><b>Ivan Pazhitnykh</b></sub>](http://linkedin.com/in/drapegnik)<br />[💻](https://github.com/paypal/downshift/commits?author=Drapegnik "Code") [⚠️](https://github.com/paypal/downshift/commits?author=Drapegnik "Tests") | [<img src="https://avatars0.githubusercontent.com/u/61776?v=4" width="100px;"/><br /><sub><b>Luis Merino</b></sub>](https://github.com/Rendez)<br />[📖](https://github.com/paypal/downshift/commits?author=Rendez "Documentation") |
-| [<img src="https://avatars0.githubusercontent.com/u/8746094?v=4" width="100px;"/><br /><sub><b>Andrew Hansen</b></sub>](http://twitter.com/arahansen)<br />[💻](https://github.com/paypal/downshift/commits?author=arahansen "Code") [⚠️](https://github.com/paypal/downshift/commits?author=arahansen "Tests") | [<img src="https://avatars3.githubusercontent.com/u/20307225?v=4" width="100px;"/><br /><sub><b>John Whiles</b></sub>](http://www.johnwhiles.com)<br />[💻](https://github.com/paypal/downshift/commits?author=Jwhiles "Code") | [<img src="https://avatars1.githubusercontent.com/u/1288694?v=4" width="100px;"/><br /><sub><b>Justin Hall</b></sub>](https://github.com/wKovacs64)<br />[🚇](#infra-wKovacs64 "Infrastructure (Hosting, Build-Tools, etc)") |
+| [<img src="https://avatars0.githubusercontent.com/u/8746094?v=4" width="100px;"/><br /><sub><b>Andrew Hansen</b></sub>](http://twitter.com/arahansen)<br />[💻](https://github.com/paypal/downshift/commits?author=arahansen "Code") [⚠️](https://github.com/paypal/downshift/commits?author=arahansen "Tests") | [<img src="https://avatars3.githubusercontent.com/u/20307225?v=4" width="100px;"/><br /><sub><b>John Whiles</b></sub>](http://www.johnwhiles.com)<br />[💻](https://github.com/paypal/downshift/commits?author=Jwhiles "Code") | [<img src="https://avatars1.githubusercontent.com/u/1288694?v=4" width="100px;"/><br /><sub><b>Justin Hall</b></sub>](https://github.com/wKovacs64)<br />[🚇](#infra-wKovacs64 "Infrastructure (Hosting, Build-Tools, etc)") | [<img src="https://avatars2.githubusercontent.com/u/7641760?v=4" width="100px;"/><br /><sub><b>Pete Nykänen</b></sub>](https://twitter.com/pete_tnt)<br />[👀](#review-petetnt "Reviewed Pull Requests") |
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.
@@ -767,5 +805,5 @@ MIT
 [controlled-components-lecture]: https://courses.reacttraining.com/courses/advanced-react/lectures/3172720
 [react-training]: https://reacttraining.com/
 [advanced-react]: https://courses.reacttraining.com/courses/enrolled/200086
-[fac]: https://medium.com/merrickchristensen/function-as-child-components-5f3920a9ace9
+[use-a-render-prop]: https://cdb.reacttraining.com/use-a-render-prop-50de598f11ce
 [semver]: http://semver.org/

--- a/other/misc-tests/__tests__/preact.js
+++ b/other/misc-tests/__tests__/preact.js
@@ -22,7 +22,7 @@ import render from 'preact-render-to-string'
 import Downshift from '../../../preact'
 
 test('works with preact', () => {
-  const childSpy = jest.fn(({getInputProps, getItemProps}) => (
+  const renderSpy = jest.fn(({getInputProps, getItemProps}) => (
     <div>
       <input {...getInputProps()} />
       <div>
@@ -31,9 +31,9 @@ test('works with preact', () => {
       </div>
     </div>
   ))
-  const ui = <Downshift>{childSpy}</Downshift>
+  const ui = <Downshift render={renderSpy} />
   render(ui)
-  expect(childSpy).toHaveBeenCalledWith(
+  expect(renderSpy).toHaveBeenCalledWith(
     expect.objectContaining({
       isOpen: false,
       highlightedIndex: null,
@@ -45,12 +45,12 @@ test('works with preact', () => {
 
 test('can render a composite component', () => {
   const Div = ({innerRef, ...props}) => <div {...props} ref={innerRef} />
-  const childSpy = jest.fn(({getRootProps}) => (
+  const renderSpy = jest.fn(({getRootProps}) => (
     <Div {...getRootProps({refKey: 'innerRef'})} />
   ))
-  const ui = <Downshift>{childSpy}</Downshift>
+  const ui = <Downshift render={renderSpy} />
   render(ui)
-  expect(childSpy).toHaveBeenCalledWith(
+  expect(renderSpy).toHaveBeenCalledWith(
     expect.objectContaining({
       isOpen: false,
       highlightedIndex: null,
@@ -88,12 +88,18 @@ test('getInputProps composes onChange with onInput', () => {
   expect(onInput).toHaveBeenCalledWith(fakeEvent)
 })
 
+test('can use children instead of render prop', () => {
+  const childrenSpy = jest.fn()
+  render(<Downshift>{childrenSpy}</Downshift>)
+  expect(childrenSpy).toHaveBeenCalledTimes(1)
+})
+
 function setup({children = () => <div />, ...props} = {}) {
   let renderArg
-  const childSpy = jest.fn(controllerArg => {
+  const renderSpy = jest.fn(controllerArg => {
     renderArg = controllerArg
     return children(controllerArg)
   })
-  const ui = <Downshift {...props}>{childSpy}</Downshift>
-  return {childSpy, ui, ...renderArg}
+  const ui = <Downshift {...props}>{renderSpy}</Downshift>
+  return {renderSpy, ui, ...renderArg}
 }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "enzyme-adapter-react-16": "^1.1.0",
     "enzyme-to-json": "^3.2.2",
     "jest-serializer-html": "^4.0.1",
-    "kcd-scripts": "^0.30.1",
+    "kcd-scripts": "^0.30.2",
     "preact": "^8.2.6",
     "preact-render-to-string": "^3.7.0",
     "preval.macro": "^1.0.2",

--- a/src/__tests__/downshift.get-button-props.js
+++ b/src/__tests__/downshift.get-button-props.js
@@ -3,34 +3,34 @@ import {mount} from 'enzyme'
 import Downshift from '../'
 
 test('space on button opens and closes the menu', () => {
-  const {button, childSpy} = setup()
+  const {button, renderSpy} = setup()
   button.simulate('keydown', {key: ' '})
-  expect(childSpy).toHaveBeenLastCalledWith(
+  expect(renderSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({isOpen: true}),
   )
   button.simulate('keydown', {key: ' '})
-  expect(childSpy).toHaveBeenLastCalledWith(
+  expect(renderSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({isOpen: false}),
   )
 })
 
 test('clicking on the button opens and closes the menu', () => {
-  const {button, childSpy} = setup()
+  const {button, renderSpy} = setup()
   button.simulate('click')
-  expect(childSpy).toHaveBeenLastCalledWith(
+  expect(renderSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({isOpen: true}),
   )
   button.simulate('click')
-  expect(childSpy).toHaveBeenLastCalledWith(
+  expect(renderSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({isOpen: false}),
   )
 })
 
 test('button ignores key events it does not handle', () => {
-  const {button, childSpy} = setup()
-  childSpy.mockClear()
+  const {button, renderSpy} = setup()
+  renderSpy.mockClear()
   button.simulate('keydown', {key: 's'})
-  expect(childSpy).not.toHaveBeenCalled()
+  expect(renderSpy).not.toHaveBeenCalled()
 })
 
 test('getButtonProps returns all given props', () => {
@@ -66,7 +66,7 @@ test(`getButtonProps doesn't include event handlers when disabled is passed (for
 
 function setup({buttonProps, Button = props => <button {...props} />} = {}) {
   let renderArg
-  const childSpy = jest.fn(controllerArg => {
+  const renderSpy = jest.fn(controllerArg => {
     renderArg = controllerArg
     return (
       <div>
@@ -74,7 +74,7 @@ function setup({buttonProps, Button = props => <button {...props} />} = {}) {
       </div>
     )
   })
-  const wrapper = mount(<Downshift>{childSpy}</Downshift>)
+  const wrapper = mount(<Downshift render={renderSpy} />)
   const button = wrapper.find('button')
-  return {button, childSpy, ...renderArg}
+  return {button, renderSpy, ...renderArg}
 }

--- a/src/__tests__/downshift.get-input-props.js
+++ b/src/__tests__/downshift.get-input-props.js
@@ -15,111 +15,111 @@ const colors = [
 ]
 
 test('manages arrow up and down behavior', () => {
-  const {Component, childSpy} = setup()
+  const {Component, renderSpy} = setup()
   const wrapper = mount(<Component />)
   const input = wrapper.find(sel('input'))
   // ↓
   input.simulate('keydown', {key: 'ArrowDown'})
-  expect(childSpy).toHaveBeenLastCalledWith(
+  expect(renderSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({isOpen: true, highlightedIndex: null}),
   )
 
   // ↓
   input.simulate('keydown', {key: 'ArrowDown'})
-  expect(childSpy).toHaveBeenLastCalledWith(
+  expect(renderSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({highlightedIndex: 0}),
   )
 
   // ↓
   input.simulate('keydown', {key: 'ArrowDown'})
-  expect(childSpy).toHaveBeenLastCalledWith(
+  expect(renderSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({highlightedIndex: 1}),
   )
 
   // <Shift>↓
   input.simulate('keydown', {key: 'ArrowDown', shiftKey: true})
-  expect(childSpy).toHaveBeenLastCalledWith(
+  expect(renderSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({highlightedIndex: 6}),
   )
 
   // ↑
   input.simulate('keydown', {key: 'ArrowUp'})
-  expect(childSpy).toHaveBeenLastCalledWith(
+  expect(renderSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({highlightedIndex: 5}),
   )
 
   // <Shift>↑
   input.simulate('keydown', {key: 'ArrowUp', shiftKey: true})
-  expect(childSpy).toHaveBeenLastCalledWith(
+  expect(renderSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({highlightedIndex: 0}),
   )
 
   // ↑
   input.simulate('keydown', {key: 'ArrowUp'})
-  expect(childSpy).toHaveBeenLastCalledWith(
+  expect(renderSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({highlightedIndex: colors.length - 1}),
   )
 
   // ↓
   input.simulate('keydown', {key: 'ArrowDown'})
-  expect(childSpy).toHaveBeenLastCalledWith(
+  expect(renderSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({highlightedIndex: 0}),
   )
 })
 
 test('arrow key down events do nothing when no items are rendered', () => {
-  const {Component, childSpy} = setup({items: []})
+  const {Component, renderSpy} = setup({items: []})
   const wrapper = mount(<Component />)
   const input = wrapper.find(sel('input'))
   // ↓↓
   input.simulate('keydown', {key: 'ArrowDown'})
   input.simulate('keydown', {key: 'ArrowDown'})
-  expect(childSpy).toHaveBeenLastCalledWith(
+  expect(renderSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({highlightedIndex: null}),
   )
 })
 
 test('arrow up on a closed menu opens the menu', () => {
-  const {Component, childSpy} = setup()
+  const {Component, renderSpy} = setup()
   const wrapper = mount(<Component />)
   const input = wrapper.find(sel('input'))
   // ↑
   input.simulate('keydown', {key: 'ArrowUp'})
-  expect(childSpy).toHaveBeenLastCalledWith(
+  expect(renderSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({isOpen: true, highlightedIndex: null}),
   )
 
   // ↑
   input.simulate('keydown', {key: 'ArrowUp'})
-  expect(childSpy).toHaveBeenLastCalledWith(
+  expect(renderSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({highlightedIndex: colors.length - 1}),
   )
 })
 
 test('enter on an input with a closed menu does nothing', () => {
-  const {Component, childSpy} = setup()
+  const {Component, renderSpy} = setup()
   const wrapper = mount(<Component />)
   const input = wrapper.find(sel('input'))
   // ENTER
-  childSpy.mockClear()
+  renderSpy.mockClear()
   input.simulate('keydown', {key: 'Enter'})
   // does not even rerender
-  expect(childSpy).not.toHaveBeenCalled()
+  expect(renderSpy).not.toHaveBeenCalled()
 })
 
 test('enter on an input with an open menu does nothing without a highlightedIndex', () => {
-  const {Component, childSpy} = setup()
+  const {Component, renderSpy} = setup()
   const wrapper = mount(<Component isOpen={true} />)
   const input = wrapper.find(sel('input'))
   // ENTER
-  childSpy.mockClear()
+  renderSpy.mockClear()
   input.simulate('keydown', {key: 'Enter'})
   // does not even rerender
-  expect(childSpy).not.toHaveBeenCalled()
+  expect(renderSpy).not.toHaveBeenCalled()
 })
 
 test('enter on an input with an open menu and a highlightedIndex selects that item', () => {
-  const {Component, childSpy} = setup()
+  const {Component, renderSpy} = setup()
   const onChange = jest.fn()
   const isOpen = true
   const wrapper = mount(<Component isOpen={isOpen} onChange={onChange} />)
@@ -136,17 +136,17 @@ test('enter on an input with an open menu and a highlightedIndex selects that it
     inputValue: colors[0],
   })
   expect(onChange).toHaveBeenCalledWith(colors[0], newState)
-  expect(childSpy).toHaveBeenLastCalledWith(newState)
+  expect(renderSpy).toHaveBeenLastCalledWith(newState)
 })
 
 test('escape on an input without a selection should reset downshift and close the menu', () => {
-  const {Component, childSpy} = setup()
+  const {Component, renderSpy} = setup()
   const wrapper = mount(<Component />)
   const input = wrapper.find(sel('input'))
   input.simulate('change', {target: {value: 'p'}})
   input.simulate('keydown', {key: 'Escape'})
   expect(input.instance().value).toBe('')
-  expect(childSpy).toHaveBeenLastCalledWith(
+  expect(renderSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({
       isOpen: false,
       inputValue: '',
@@ -155,9 +155,9 @@ test('escape on an input without a selection should reset downshift and close th
 })
 
 test('escape on an input with a selection should reset downshift and close the menu', () => {
-  const {input, childSpy, items} = setupDownshiftWithState()
+  const {input, renderSpy, items} = setupDownshiftWithState()
   input.simulate('keydown', {key: 'Escape'})
-  expect(childSpy).toHaveBeenLastCalledWith(
+  expect(renderSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({
       isOpen: false,
       inputValue: items[0],
@@ -167,9 +167,9 @@ test('escape on an input with a selection should reset downshift and close the m
 })
 
 test('on input blur resets the state', () => {
-  const {input, childSpy, items} = setupDownshiftWithState()
+  const {input, renderSpy, items} = setupDownshiftWithState()
   input.simulate('blur')
-  expect(childSpy).toHaveBeenLastCalledWith(
+  expect(renderSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({
       isOpen: false,
       inputValue: items[0],
@@ -179,36 +179,36 @@ test('on input blur resets the state', () => {
 })
 
 test('on input blur does not reset the state when the mouse is down', () => {
-  const {input, childSpy} = setupDownshiftWithState()
+  const {input, renderSpy} = setupDownshiftWithState()
   // mousedown somwhere
   document.body.dispatchEvent(
     new window.MouseEvent('mousedown', {bubbles: true}),
   )
   input.simulate('blur')
-  expect(childSpy).not.toHaveBeenCalled()
+  expect(renderSpy).not.toHaveBeenCalled()
 })
 
 test('keydown of things that are not handled do nothing', () => {
   const modifiers = [undefined, 'Shift']
-  const {Component, childSpy} = setup()
+  const {Component, renderSpy} = setup()
   const wrapper = mount(<Component />)
   const input = wrapper.find(sel('input'))
-  childSpy.mockClear()
+  renderSpy.mockClear()
   modifiers.forEach(key => {
     input.simulate('keydown', {key})
   })
   // does not even rerender
-  expect(childSpy).not.toHaveBeenCalled()
+  expect(renderSpy).not.toHaveBeenCalled()
 })
 
 test('highlightedIndex uses the given itemCount prop to determine the last index', () => {
-  const {Component, childSpy} = setup()
+  const {Component, renderSpy} = setup()
   const itemCount = 200
   const wrapper = mount(<Component itemCount={itemCount} isOpen={true} />)
   const input = wrapper.find(sel('input'))
   // ↑
   input.simulate('keydown', {key: 'ArrowUp'})
-  expect(childSpy).toHaveBeenLastCalledWith(
+  expect(renderSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({highlightedIndex: itemCount - 1}),
   )
 })
@@ -222,7 +222,7 @@ test('Enter when there is no item at index 0 still selects the highlighted item'
     {value: 'bird', index: 3},
     {value: 'cheetah', index: 4},
   ]
-  const {Component, childSpy} = setup({items})
+  const {Component, renderSpy} = setup({items})
   const wrapper = mount(
     <Component
       itemToString={i => (i ? i.value : '')}
@@ -234,9 +234,9 @@ test('Enter when there is no item at index 0 still selects the highlighted item'
   // ↓
   input.simulate('keydown', {key: 'ArrowDown'})
   // ENTER
-  childSpy.mockClear()
+  renderSpy.mockClear()
   input.simulate('keydown', {key: 'Enter'})
-  expect(childSpy).toHaveBeenLastCalledWith(
+  expect(renderSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({
       selectedItem: items[1],
     }),
@@ -264,7 +264,7 @@ test(`getInputProps doesn't include event handlers when disabled is passed (for 
 
 function setupDownshiftWithState() {
   const items = ['animal', 'bug', 'cat']
-  const {Component, childSpy} = setup({items})
+  const {Component, renderSpy} = setup({items})
   const wrapper = mount(<Component />)
   const input = wrapper.find(sel('input'))
   input.simulate('keydown')
@@ -277,13 +277,13 @@ function setupDownshiftWithState() {
   // ↓
   input.simulate('keydown', {key: 'ArrowDown'})
   input.simulate('change', {target: {value: 'bu'}})
-  childSpy.mockClear()
-  return {childSpy, input, items, wrapper}
+  renderSpy.mockClear()
+  return {renderSpy, input, items, wrapper}
 }
 
 function setup({items = colors} = {}) {
   /* eslint-disable react/jsx-closing-bracket-location */
-  const childSpy = jest.fn(({isOpen, getInputProps, getItemProps}) => (
+  const renderSpy = jest.fn(({isOpen, getInputProps, getItemProps}) => (
     <div>
       <input {...getInputProps({'data-test': 'input'})} />
       {isOpen && (
@@ -302,23 +302,23 @@ function setup({items = colors} = {}) {
   ))
 
   function BasicDownshift(props) {
-    return <Downshift {...props}>{childSpy}</Downshift>
+    return <Downshift {...props} render={renderSpy} />
   }
   return {
     Component: BasicDownshift,
-    childSpy,
+    renderSpy,
   }
 }
 
 function setupWithDownshiftController() {
   let renderArg
   mount(
-    <Downshift>
-      {controllerArg => {
+    <Downshift
+      render={controllerArg => {
         renderArg = controllerArg
         return null
       }}
-    </Downshift>,
+    />,
   )
   return renderArg
 }

--- a/src/__tests__/downshift.get-item-props.js
+++ b/src/__tests__/downshift.get-item-props.js
@@ -17,12 +17,12 @@ afterEach(() => {
 test('clicking on a DOM node within an item selects that item', () => {
   // inspiration: https://github.com/paypal/downshift/issues/113
   const items = ['Chess', 'Dominion', 'Checkers']
-  const {Component, childSpy} = setup({items})
+  const {Component, renderSpy} = setup({items})
   const wrapper = mount(<Component />)
   const firstButton = wrapper.find('button').first()
-  childSpy.mockClear()
+  renderSpy.mockClear()
   firstButton.simulate('click')
-  expect(childSpy).toHaveBeenCalledWith(
+  expect(renderSpy).toHaveBeenCalledWith(
     expect.objectContaining({
       selectedItem: items[0],
     }),
@@ -30,27 +30,27 @@ test('clicking on a DOM node within an item selects that item', () => {
 })
 
 test('clicking anywhere within the rendered downshift but outside an item does not select an item', () => {
-  const childSpy = jest.fn(() => (
+  const renderSpy = jest.fn(() => (
     <div>
       <button />
     </div>
   ))
-  const wrapper = mount(<Downshift>{childSpy}</Downshift>)
-  childSpy.mockClear()
+  const wrapper = mount(<Downshift render={renderSpy} />)
+  renderSpy.mockClear()
   wrapper
     .find('button')
     .first()
     .simulate('click')
-  expect(childSpy).not.toHaveBeenCalled()
+  expect(renderSpy).not.toHaveBeenCalled()
 })
 
 test('on mouseenter of an item updates the highlightedIndex to that item', () => {
-  const {Component, childSpy} = setup()
+  const {Component, renderSpy} = setup()
   const wrapper = mount(<Component />)
   const thirdButton = wrapper.find('[data-test="item-2"]')
-  childSpy.mockClear()
+  renderSpy.mockClear()
   thirdButton.simulate('mouseenter')
-  expect(childSpy).toHaveBeenCalledWith(
+  expect(renderSpy).toHaveBeenCalledWith(
     expect.objectContaining({
       highlightedIndex: 2,
     }),
@@ -58,12 +58,12 @@ test('on mouseenter of an item updates the highlightedIndex to that item', () =>
 })
 
 test('after selecting an item highlightedIndex should be reset to defaultHighlightIndex', () => {
-  const {Component, childSpy} = setup()
+  const {Component, renderSpy} = setup()
   const wrapper = mount(<Component defaultHighlightedIndex={1} />)
   const firstButton = wrapper.find('button').first()
-  childSpy.mockClear()
+  renderSpy.mockClear()
   firstButton.simulate('click')
-  expect(childSpy).toHaveBeenCalledWith(
+  expect(renderSpy).toHaveBeenCalledWith(
     expect.objectContaining({
       highlightedIndex: 1,
     }),
@@ -73,13 +73,13 @@ test('after selecting an item highlightedIndex should be reset to defaultHighlig
 test('getItemProps throws a helpful error when no object is given', () => {
   expect(() =>
     mount(
-      <Downshift>
-        {({getItemProps}) => (
+      <Downshift
+        render={({getItemProps}) => (
           <div>
             <span {...getItemProps()} />
           </div>
         )}
-      </Downshift>,
+      />,
     ),
   ).toThrowErrorMatchingSnapshot()
 })
@@ -87,8 +87,8 @@ test('getItemProps throws a helpful error when no object is given', () => {
 test('getItemProps defaults the index when no index is given', () => {
   expect(
     render(
-      <Downshift>
-        {({getItemProps}) => (
+      <Downshift
+        render={({getItemProps}) => (
           <div>
             <span {...getItemProps({item: 0})}>0</span>
             <span {...getItemProps({item: 1})}>1</span>
@@ -97,7 +97,7 @@ test('getItemProps defaults the index when no index is given', () => {
             <span {...getItemProps({item: 4})}>4</span>
           </div>
         )}
-      </Downshift>,
+      />,
     ),
   ).toMatchSnapshot()
 })
@@ -105,19 +105,19 @@ test('getItemProps defaults the index when no index is given', () => {
 test('getItemProps throws when no item is given', () => {
   expect(() =>
     mount(
-      <Downshift>
-        {({getItemProps}) => (
+      <Downshift
+        render={({getItemProps}) => (
           <div>
             <span {...getItemProps({index: 0})} />
           </div>
         )}
-      </Downshift>,
+      />,
     ),
   ).toThrowErrorMatchingSnapshot()
 })
 
 function setup({items = ['Chess', 'Dominion', 'Checkers']} = {}) {
-  const childSpy = jest.fn(({getItemProps}) => (
+  const renderSpy = jest.fn(({getItemProps}) => (
     <div>
       {items.map((item, index) => (
         <div
@@ -132,12 +132,15 @@ function setup({items = ['Chess', 'Dominion', 'Checkers']} = {}) {
   ))
   function BasicDownshift(props) {
     return (
-      <Downshift isOpen={true} onChange={() => {}} {...props}>
-        {childSpy}
-      </Downshift>
+      <Downshift
+        isOpen={true}
+        onChange={() => {}}
+        {...props}
+        render={renderSpy}
+      />
     )
   }
-  return {Component: BasicDownshift, childSpy}
+  return {Component: BasicDownshift, renderSpy}
 }
 
 /* eslint no-console:0 */

--- a/src/__tests__/downshift.get-label-props.js
+++ b/src/__tests__/downshift.get-label-props.js
@@ -60,8 +60,9 @@ function BasicDownshift({
   ...rest
 }) {
   return (
-    <Downshift {...rest}>
-      {({getInputProps, getLabelProps}) => {
+    <Downshift
+      {...rest}
+      render={({getInputProps, getLabelProps}) => {
         if (getLabelPropsFirst) {
           labelProps = getLabelProps(labelProps)
           inputProps = getInputProps(inputProps)
@@ -76,7 +77,7 @@ function BasicDownshift({
           </div>
         )
       }}
-    </Downshift>
+    />
   )
 }
 

--- a/src/__tests__/downshift.get-root-props.js
+++ b/src/__tests__/downshift.get-root-props.js
@@ -20,95 +20,97 @@ test('no children provided renders nothing', () => {
 })
 
 test('returning null renders nothing', () => {
-  const MyComponent = () => <Downshift>{() => null}</Downshift>
+  const MyComponent = () => <Downshift render={() => null} />
   expect(mount(<MyComponent />).html()).toBe(null)
 })
 
 test('returning a composite component without calling getRootProps results in an error', () => {
-  const MyComponent = () => <Downshift>{() => <MyDiv />}</Downshift>
+  const MyComponent = () => <Downshift render={() => <MyDiv />} />
   expect(() => mount(<MyComponent />)).toThrowErrorMatchingSnapshot()
 })
 
 test('returning a composite component and calling getRootProps without a refKey results in an error', () => {
   const MyComponent = () => (
-    <Downshift>{({getRootProps}) => <MyDiv {...getRootProps()} />}</Downshift>
+    <Downshift render={({getRootProps}) => <MyDiv {...getRootProps()} />} />
   )
   expect(() => mount(<MyComponent />)).toThrowErrorMatchingSnapshot()
 })
 
 test('returning a DOM element and calling getRootProps with a refKey results in an error', () => {
   const MyComponent = () => (
-    <Downshift>
-      {({getRootProps}) => <div {...getRootProps({refKey: 'blah'})} />}
-    </Downshift>
+    <Downshift
+      render={({getRootProps}) => <div {...getRootProps({refKey: 'blah'})} />}
+    />
   )
   expect(() => mount(<MyComponent />)).toThrowErrorMatchingSnapshot()
 })
 
 test('not applying the ref prop results in an error', () => {
   const MyComponent = () => (
-    <Downshift>
-      {({getRootProps}) => {
+    <Downshift
+      render={({getRootProps}) => {
         const {onClick} = getRootProps()
         return <div onClick={onClick} />
       }}
-    </Downshift>
+    />
   )
   expect(() => mount(<MyComponent />)).toThrowErrorMatchingSnapshot()
 })
 
 test('renders fine when rendering a composite component and applying getRootProps properly', () => {
   const MyComponent = () => (
-    <Downshift>
-      {({getRootProps}) => <MyDiv {...getRootProps({refKey: 'innerRef'})} />}
-    </Downshift>
+    <Downshift
+      render={({getRootProps}) => (
+        <MyDiv {...getRootProps({refKey: 'innerRef'})} />
+      )}
+    />
   )
   expect(() => mount(<MyComponent />)).not.toThrow()
 })
 
 test('returning a composite component and calling getRootProps without a refKey does not result in an error if suppressRefError is true', () => {
   const MyComponent = () => (
-    <Downshift>
-      {({getRootProps}) => (
+    <Downshift
+      render={({getRootProps}) => (
         <MyDiv {...getRootProps({}, {suppressRefError: true})} />
       )}
-    </Downshift>
+    />
   )
   expect(() => mount(<MyComponent />)).not.toThrow()
 })
 
 test('returning a DOM element and calling getRootProps with a refKey does not result in an error if suppressRefError is true', () => {
   const MyComponent = () => (
-    <Downshift>
-      {({getRootProps}) => (
+    <Downshift
+      render={({getRootProps}) => (
         <div {...getRootProps({refKey: 'blah'}, {suppressRefError: true})} />
       )}
-    </Downshift>
+    />
   )
   expect(() => mount(<MyComponent />)).not.toThrow()
 })
 
 test('not applying the ref prop results in an error does not result in an error if suppressRefError is true', () => {
   const MyComponent = () => (
-    <Downshift>
-      {({getRootProps}) => {
+    <Downshift
+      render={({getRootProps}) => {
         const {onClick} = getRootProps({}, {suppressRefError: true})
         return <div onClick={onClick} />
       }}
-    </Downshift>
+    />
   )
   expect(() => mount(<MyComponent />)).not.toThrow()
 })
 
 test('renders fine when rendering a composite component and applying getRootProps properly even if suppressRefError is true', () => {
   const MyComponent = () => (
-    <Downshift>
-      {({getRootProps}) => (
+    <Downshift
+      render={({getRootProps}) => (
         <MyDiv
           {...getRootProps({refKey: 'innerRef'}, {suppressRefError: true})}
         />
       )}
-    </Downshift>
+    />
   )
   expect(() => mount(<MyComponent />)).not.toThrow()
 })

--- a/src/__tests__/downshift.props.js
+++ b/src/__tests__/downshift.props.js
@@ -186,10 +186,10 @@ function mouseDownAndUp(node) {
 
 function setup({children = () => <div />, ...props} = {}) {
   let renderArg
-  const childSpy = jest.fn(controllerArg => {
+  const renderSpy = jest.fn(controllerArg => {
     renderArg = controllerArg
     return children(controllerArg)
   })
-  const wrapper = mount(<Downshift {...props}>{childSpy}</Downshift>)
-  return {childSpy, wrapper, ...renderArg}
+  const wrapper = mount(<Downshift {...props} render={renderSpy} />)
+  return {renderSpy, wrapper, ...renderArg}
 }

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -23,6 +23,7 @@ import {
 class Downshift extends Component {
   static propTypes = {
     children: PropTypes.func,
+    render: PropTypes.func,
     defaultHighlightedIndex: PropTypes.number,
     defaultSelectedItem: PropTypes.any,
     defaultInputValue: PropTypes.string,
@@ -779,8 +780,9 @@ class Downshift extends Component {
     this.cleanup() // avoids memory leak
   }
 
+  // eslint-disable-next-line complexity
   render() {
-    const children = unwrapArray(this.props.children, noop)
+    const children = unwrapArray(this.props.render || this.props.children, noop)
     // because the items are rerendered every time we call the children
     // we clear this out each render and
     this.clearItems()

--- a/stories/examples/apollo.js
+++ b/stories/examples/apollo.js
@@ -6,7 +6,7 @@ import {
   gql,
   graphql,
 } from 'react-apollo'
-import Autocomplete from '../../src'
+import Downshift from '../../src'
 
 export default Examples
 
@@ -31,8 +31,9 @@ function Examples() {
 
 function ApolloAutocomplete() {
   return (
-    <Autocomplete onChange={selectedItem => alert(selectedItem)}>
-      {({
+    <Downshift
+      onChange={selectedItem => alert(selectedItem)}
+      render={({
         inputValue,
         getInputProps,
         getItemProps,
@@ -55,7 +56,7 @@ function ApolloAutocomplete() {
           ) : null}
         </div>
       )}
-    </Autocomplete>
+    />
   )
 }
 

--- a/stories/examples/axios.js
+++ b/stories/examples/axios.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react'
 import axios from 'axios'
-import Autocomplete from '../../src'
+import Downshift from '../../src'
 
 function debounce(fn, time) {
   let timeoutId
@@ -37,8 +37,8 @@ class AxiosAutocomplete extends Component {
 
   render() {
     return (
-      <Autocomplete>
-        {({
+      <Downshift
+        render={({
           selectedItem,
           getInputProps,
           getItemProps,
@@ -93,7 +93,7 @@ class AxiosAutocomplete extends Component {
             </div>
           )
         }}
-      </Autocomplete>
+      />
     )
   }
 }

--- a/stories/examples/basic.js
+++ b/stories/examples/basic.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react'
 import glamorous, {Div} from 'glamorous'
 import matchSorter from 'match-sorter'
-import Autocomplete from '../../src'
+import Downshift from '../../src'
 
 class Examples extends Component {
   state = {
@@ -105,8 +105,9 @@ function Root({innerRef, ...rest}) {
 }
 function BasicAutocomplete({items, onChange}) {
   return (
-    <Autocomplete onChange={onChange}>
-      {({
+    <Downshift
+      onChange={onChange}
+      render={({
         getInputProps,
         getItemProps,
         getRootProps,
@@ -145,7 +146,7 @@ function BasicAutocomplete({items, onChange}) {
           )}
         </Root>
       )}
-    </Autocomplete>
+    />
   )
 }
 export default Examples

--- a/stories/examples/controlled.js
+++ b/stories/examples/controlled.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react'
 import glamorous, {Div} from 'glamorous'
 import matchSorter from 'match-sorter'
-import Autocomplete from '../../src'
+import Downshift from '../../src'
 
 const Input = glamorous.input({
   fontSize: 14,
@@ -48,9 +48,7 @@ class Examples extends Component {
       type,
     } = changes
     isOpen =
-      type === Autocomplete.stateChangeTypes.mouseUp
-        ? this.state.isOpen
-        : isOpen
+      type === Downshift.stateChangeTypes.mouseUp ? this.state.isOpen : isOpen
     this.setState({
       selectedColor: selectedItem,
       isOpen,
@@ -172,8 +170,9 @@ const Item = glamorous.div(
 
 function ControlledAutocomplete({onInputChange, items, ...rest}) {
   return (
-    <Autocomplete {...rest}>
-      {({
+    <Downshift
+      {...rest}
+      render={({
         getInputProps,
         getItemProps,
         highlightedIndex,
@@ -208,7 +207,7 @@ function ControlledAutocomplete({onInputChange, items, ...rest}) {
           )}
         </div>
       )}
-    </Autocomplete>
+    />
   )
 }
 export default Examples

--- a/stories/examples/dropdown.js
+++ b/stories/examples/dropdown.js
@@ -32,8 +32,10 @@ const Item = glamorous.div(
 )
 
 const Dropdown = ({items, selectedItem, onChange}) => (
-  <Downshift selectedItem={selectedItem} onChange={onChange}>
-    {({
+  <Downshift
+    selectedItem={selectedItem}
+    onChange={onChange}
+    render={({
       isOpen,
       getButtonProps,
       getItemProps,
@@ -74,7 +76,7 @@ const Dropdown = ({items, selectedItem, onChange}) => (
         </div>
       </div>
     )}
-  </Downshift>
+  />
 )
 
 class Examples extends Component {

--- a/stories/examples/multiple.js
+++ b/stories/examples/multiple.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react'
 import glamorous, {Div} from 'glamorous'
 import matchSorter from 'match-sorter'
-import Autocomplete from '../../src'
+import Downshift from '../../src'
 
 class Examples extends Component {
   state = {
@@ -125,12 +125,11 @@ class MultipleAutocomplete extends React.Component {
     const indices = mapItemIndex(items, values)
 
     return (
-      <Autocomplete
+      <Downshift
         inputValue={this.state.input}
         onChange={this.handleChange}
         selectedItem={values}
-      >
-        {({
+        render={({
           getInputProps,
           getItemProps,
           getRootProps,
@@ -195,7 +194,7 @@ class MultipleAutocomplete extends React.Component {
             )}
           </Root>
         )}
-      </Autocomplete>
+      />
     )
   }
 

--- a/stories/examples/react-autosuggest.js
+++ b/stories/examples/react-autosuggest.js
@@ -101,8 +101,7 @@ function BasicAutocomplete({
       selectedItem={selectedItem}
       onChange={onChange}
       onUserAction={onUserAction}
-    >
-      {({getInputProps, getItemProps, highlightedIndex, isOpen}) => (
+      render={({getInputProps, getItemProps, highlightedIndex, isOpen}) => (
         <div>
           <input {...getInputProps({placeholder: 'Enter color here'})} />
           {isOpen && (
@@ -131,7 +130,7 @@ function BasicAutocomplete({
           )}
         </div>
       )}
-    </Downshift>
+    />
   )
 }
 export default Examples

--- a/stories/examples/react-instantsearch.js
+++ b/stories/examples/react-instantsearch.js
@@ -1,17 +1,16 @@
 import React from 'react'
 import {InstantSearch, Highlight} from 'react-instantsearch/dom'
 import {connectAutoComplete} from 'react-instantsearch/connectors'
-import Autocomplete from '../../src'
+import Downshift from '../../src'
 
 export default Examples
 
 function RawAutoComplete({refine, hits}) {
   return (
-    <Autocomplete
+    <Downshift
       itemToString={i => (i ? i.name : i)}
       onChange={item => alert(JSON.stringify(item))}
-    >
-      {({
+      render={({
         getInputProps,
         getItemProps,
         selectedItem,
@@ -47,7 +46,7 @@ function RawAutoComplete({refine, hits}) {
           )}
         </div>
       )}
-    </Autocomplete>
+    />
   )
 }
 

--- a/stories/examples/react-popper.js
+++ b/stories/examples/react-popper.js
@@ -45,8 +45,9 @@ class ReactPopperAutocomplete extends PureComponent {
         }}
       >
         <Manager>
-          <Downshift style={{display: 'inline-block', position: 'relative'}}>
-            {({
+          <Downshift
+            style={{display: 'inline-block', position: 'relative'}}
+            render={({
               getInputProps,
               getItemProps,
               inputValue,
@@ -91,7 +92,7 @@ class ReactPopperAutocomplete extends PureComponent {
                 </div>
               </div>
             )}
-          </Downshift>
+          />
         </Manager>
       </div>
     )

--- a/stories/examples/semantic-ui.js
+++ b/stories/examples/semantic-ui.js
@@ -3,7 +3,7 @@ import matchSorter from 'match-sorter'
 import glamorous, {Div} from 'glamorous'
 import items from '../countries'
 
-import Autocomplete from '../../src'
+import Downshift from '../../src'
 
 export default Examples
 
@@ -130,13 +130,12 @@ function advancedFilter(theItems, value) {
 
 function SemanticUIAutocomplete() {
   return (
-    <Autocomplete
+    <Downshift
       itemToString={i => (i ? i.name : '')}
       style={{
         width: '250px',
       }}
-    >
-      {({
+      render={({
         highlightedIndex,
         isOpen,
         clearSelection,
@@ -189,7 +188,7 @@ function SemanticUIAutocomplete() {
           )}
         </Div>
       )}
-    </Autocomplete>
+    />
   )
 }
 

--- a/stories/examples/semi-controlled-list.js
+++ b/stories/examples/semi-controlled-list.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react'
 import glamorous, {Div} from 'glamorous'
 import matchSorter from 'match-sorter'
-import Autocomplete from '../../src'
+import Downshift from '../../src'
 
 const Input = glamorous.input({
   fontSize: 14,
@@ -176,8 +176,9 @@ const Item = glamorous.div(
 
 function ControlledAutocomplete({onInputChange, items, ...rest}) {
   return (
-    <Autocomplete {...rest}>
-      {({
+    <Downshift
+      {...rest}
+      render={({
         getInputProps,
         getItemProps,
         highlightedIndex,
@@ -212,7 +213,7 @@ function ControlledAutocomplete({onInputChange, items, ...rest}) {
           )}
         </div>
       )}
-    </Autocomplete>
+    />
   )
 }
 export default Examples

--- a/stories/examples/semi-controlled.js
+++ b/stories/examples/semi-controlled.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react'
 import glamorous, {Div} from 'glamorous'
 import matchSorter from 'match-sorter'
-import Autocomplete from '../../src'
+import Downshift from '../../src'
 
 const Input = glamorous.input({
   fontSize: 14,
@@ -118,8 +118,9 @@ const Item = glamorous.div(
 
 function ControlledAutocomplete({onInputChange, items, ...rest}) {
   return (
-    <Autocomplete {...rest}>
-      {({
+    <Downshift
+      {...rest}
+      render={({
         getInputProps,
         getItemProps,
         highlightedIndex,
@@ -154,7 +155,7 @@ function ControlledAutocomplete({onInputChange, items, ...rest}) {
           )}
         </div>
       )}
-    </Autocomplete>
+    />
   )
 }
 export default Examples

--- a/stories/examples/windowing-with-react-tiny-virtual-list.js
+++ b/stories/examples/windowing-with-react-tiny-virtual-list.js
@@ -38,8 +38,7 @@ class Example extends React.Component {
             itemToString={i => (i ? i.name : '')}
             onStateChange={this.handleStateChange}
             itemCount={items.length}
-          >
-            {({
+            render={({
               getInputProps,
               getItemProps,
               isOpen,
@@ -78,7 +77,7 @@ class Example extends React.Component {
                 ) : null}
               </div>
             )}
-          </Downshift>
+          />
         </div>
       </div>
     )

--- a/stories/examples/windowing-with-react-virtualized.js
+++ b/stories/examples/windowing-with-react-virtualized.js
@@ -32,8 +32,7 @@ class Example extends React.Component {
             itemToString={i => (i ? i.name : '')}
             onStateChange={this.handleStateChange}
             itemCount={items.length}
-          >
-            {({
+            render={({
               getInputProps,
               getItemProps,
               isOpen,
@@ -71,7 +70,7 @@ class Example extends React.Component {
                 ) : null}
               </div>
             )}
-          </Downshift>
+          />
         </div>
       </div>
     )


### PR DESCRIPTION
**What**: This also moves all examples and tests to use render prop and adds one test to verify the children prop still works

<!-- Why are these changes necessary? -->
**Why**: Closes #258 

I'm trying to bring some cohesion to the render prop idea.

<!-- How were these changes implemented? -->
**How**: the source code change was as simple as `this.props.render ||`. Most of the changes are updating the stories, tests, and docs to use the render prop instead.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A

<!-- feel free to add additional comments -->

NOTE: The children prop still works fine. I don't know whether I'll ever drop support for it. Can't think of a reason why I would...