### PR TITLE
feat(itemCount): add `setItemCount` and `unsetItemCount`

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,6 +581,8 @@ These are functions you can call to change the state of the downshift component.
 | `setHighlightedIndex`   | `function(index: number, otherStateToSet: object, cb: Function)` | call to set a new highlighted index                                                                                                                                                 |
 | `toggleMenu`            | `function(otherStateToSet: object, cb: Function)`                | toggle the menu open state                                                                                                                                                          |
 | `reset`                 | `function(otherStateToSet: object, cb: Function)`                | this resets downshift's state to a reasonable default                                                                                                                               |
+| `setItemCount`          | `function(count: number)`                                        | this sets the `itemCount`. Handy in situations where you're using windowing and the items are loaded asynchronously from within downshift (so you can't use the `itemCount` prop.   |
+| `unsetItemCount`        | `function()`                                                     | this unsets the `itemCount` which means the item count will be calculated instead by the `itemCount` prop or based on how many times you call `getItemProps`.                       |
 
 > `otherStateToSet` refers to an object to set other internal state. It is
 > recommended to avoid abusing this, but is available if you need it.

--- a/src/__tests__/downshift.get-input-props.js
+++ b/src/__tests__/downshift.get-input-props.js
@@ -213,6 +213,48 @@ test('highlightedIndex uses the given itemCount prop to determine the last index
   )
 })
 
+test('itemCount can be set and unset asynchronously', () => {
+  let downshift
+  const renderSpy = jest.fn(d => {
+    downshift = d
+    return (
+      <div>
+        <input {...d.getInputProps({'data-test': 'input'})} />
+      </div>
+    )
+  })
+  const wrapper = mount(
+    <Downshift isOpen={true} render={renderSpy} itemCount={10} />,
+  )
+  const input = wrapper.find(sel('input'))
+  const up = () => input.simulate('keydown', {key: 'ArrowUp'})
+  const down = () => input.simulate('keydown', {key: 'ArrowDown'})
+
+  downshift.setItemCount(100)
+  up()
+  expect(renderSpy).toHaveBeenLastCalledWith(
+    expect.objectContaining({highlightedIndex: 99}),
+  )
+  down()
+  expect(renderSpy).toHaveBeenLastCalledWith(
+    expect.objectContaining({highlightedIndex: 0}),
+  )
+  downshift.setItemCount(40)
+  up()
+  expect(renderSpy).toHaveBeenLastCalledWith(
+    expect.objectContaining({highlightedIndex: 39}),
+  )
+  down()
+  expect(renderSpy).toHaveBeenLastCalledWith(
+    expect.objectContaining({highlightedIndex: 0}),
+  )
+  downshift.unsetItemCount()
+  up()
+  expect(renderSpy).toHaveBeenLastCalledWith(
+    expect.objectContaining({highlightedIndex: 9}),
+  )
+})
+
 test('Enter when there is no item at index 0 still selects the highlighted item', () => {
   // test inspired by https://github.com/paypal/downshift/issues/119
   // use case is virtualized lists

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -140,6 +140,12 @@ class Downshift extends Component {
   )
   input = null
   items = []
+  // itemCount can be changed asynchronously
+  // from within downshift (so it can't come from a prop)
+  // this is why we store it as an instance and use
+  // getItemCount rather than just use items.length
+  // (to support windowing + async)
+  itemCount = null
   previousResultCount = 0
 
   /**
@@ -178,12 +184,23 @@ class Downshift extends Component {
   }
 
   getItemCount() {
-    if (this.props.itemCount === undefined) {
-      return this.items.length
-    } else {
+    // things read better this way. They're in priority order:
+    // 1. `this.itemCount`
+    // 2. `this.props.itemCount`
+    // 3. `this.items.length`
+    /* eslint-disable no-negated-condition */
+    if (this.itemCount != null) {
+      return this.itemCount
+    } else if (this.props.itemCount !== undefined) {
       return this.props.itemCount
+    } else {
+      return this.items.length
     }
+    /* eslint-enable no-negated-condition */
   }
+
+  setItemCount = count => (this.itemCount = count)
+  unsetItemCount = () => (this.itemCount = null)
 
   getItemNodeFromIndex = index => {
     return this.props.environment.document.getElementById(this.getItemId(index))
@@ -417,6 +434,8 @@ class Downshift extends Component {
       clearSelection,
       clearItems,
       reset,
+      setItemCount,
+      unsetItemCount,
     } = this
     return {
       // prop getters
@@ -437,6 +456,8 @@ class Downshift extends Component {
       setHighlightedIndex,
       clearSelection,
       clearItems,
+      setItemCount,
+      unsetItemCount,
 
       //props
       itemToString,


### PR DESCRIPTION
**What**: add `setItemCount` and `unsetItemCount` 

<!-- Why are these changes necessary? -->

**Why**: This enables developers who need to both asynchronously load options within downshift and window the results. The `itemCount` needs to be set from within downshift so they cannot reasonably use the `prop`.

<!-- How were these changes implemented? -->

**How**: Adding a member property to keep track of the set value and a getter (and unsetter as convenience) for that member property.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table N/A
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
