### PR TITLE
fix(reset): respect defaultHighlightedIndex

### DIFF
--- a/src/__tests__/downshift.props.js
+++ b/src/__tests__/downshift.props.js
@@ -133,9 +133,9 @@ test('uses given environment', () => {
 })
 
 test('can override onOuterClick callback to maintain isOpen state', () => {
-  const children = () => <div />
+  const render = () => <div />
   const onOuterClick = jest.fn()
-  const {openMenu} = setup({children, onOuterClick})
+  const {openMenu} = setup({render, onOuterClick})
   openMenu()
   mouseDownAndUp(document.body)
   expect(onOuterClick).toHaveBeenCalledTimes(1)
@@ -179,16 +179,27 @@ test('onInputValueChange called with empty string on reset', () => {
   expect(handleInputValueChange).toHaveBeenCalledWith('', expect.any(Object))
 })
 
+test('defaultHighlightedIndex will be used for the highlighted index on reset', () => {
+  const {reset, renderSpy} = setup({defaultHighlightedIndex: 0})
+  renderSpy.mockClear()
+  reset()
+  expect(renderSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      highlightedIndex: 0,
+    }),
+  )
+})
+
 function mouseDownAndUp(node) {
   node.dispatchEvent(new window.MouseEvent('mousedown', {bubbles: true}))
   node.dispatchEvent(new window.MouseEvent('mouseup', {bubbles: true}))
 }
 
-function setup({children = () => <div />, ...props} = {}) {
+function setup({render = () => <div />, ...props} = {}) {
   let renderArg
   const renderSpy = jest.fn(controllerArg => {
     renderArg = controllerArg
-    return children(controllerArg)
+    return render(controllerArg)
   })
   const wrapper = mount(<Downshift {...props} render={renderSpy} />)
   return {renderSpy, wrapper, ...renderArg}

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -716,7 +716,7 @@ class Downshift extends Component {
     this.internalSetState(
       ({selectedItem}) => ({
         isOpen: false,
-        highlightedIndex: null,
+        highlightedIndex: this.props.defaultHighlightedIndex,
         inputValue: this.props.itemToString(selectedItem),
         ...otherStateToSet,
       }),


### PR DESCRIPTION
**What**: This changes the `reset` functionality to use the `defaultHighlightedIndex` rather than `null`

<!-- Why are these changes necessary? -->

**Why**: because I think that makes the most sense.

<!-- How were these changes implemented? -->

**How**: Simple change and a test addition

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [x] Tests
* [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table N/A
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
