### PR TITLE
Consolidate scrolling of the list when highlighted index changes and never scroll from a `onMouseEnter` event (fixes #281)

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -496,6 +496,16 @@
         "code",
         "test"
       ]
+    },
+    {
+      "login": "jlongster",
+      "name": "James Long",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/17031?v=4",
+      "profile": "http://jlongster.com",
+      "contributions": [
+        "bug",
+        "code"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ autocomplete/dropdown/select/combobox components</p>
 [![downloads][downloads-badge]][npmcharts] [![version][version-badge]][package]
 [![MIT License][license-badge]][license]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-51-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-52-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs] [![Chat][chat-badge]][chat]
 [![Code of Conduct][coc-badge]][coc]
 
@@ -209,8 +209,7 @@ compute the `inputValue`.
 
 ### selectedItemChanged
 
-> `function(prevItem: any, item: any)` | defaults to: `(prevItem, item) =>
-> (prevItem !== item)`
+> `function(prevItem: any, item: any)` | defaults to: `(prevItem, item) => (prevItem !== item)`
 
 Used to determine if the new `selectedItem` has changed compared to the previous
 `selectedItem` and properly update Downshift's internal state.
@@ -279,8 +278,7 @@ This function is called anytime the internal state changes. This can be useful
 if you're using downshift as a "controlled" component, where you manage some or
 all of the state (e.g. isOpen, selectedItem, highlightedIndex, etc) and then
 pass it as props, rather than letting downshift control all its state itself.
-The parameters both take the shape of internal state (`{highlightedIndex:
-number, inputValue: string, isOpen: boolean, selectedItem: any}`) but differ
+The parameters both take the shape of internal state (`{highlightedIndex: number, inputValue: string, isOpen: boolean, selectedItem: any}`) but differ
 slightly.
 
 * `changes`: These are the properties that actually have changed since the last
@@ -434,8 +432,7 @@ below:
 
 These functions are used to apply props to the elements that you render. This
 gives you maximum flexibility to render what, when, and wherever you like. You
-call these on the element in question (for example: `<input
-{...getInputProps()}`)). It's advisable to pass all your props to that function
+call these on the element in question (for example: `<input {...getInputProps()}`)). It's advisable to pass all your props to that function
 rather than applying them on the element yourself to avoid your props being
 overridden (or overriding the props returned). For example:
 `getInputProps({onKeyUp(event) {console.log(event)}})`.
@@ -469,8 +466,7 @@ If you're rendering a composite component, `Downshift` checks that
 `getRootProps` is called and that `refKey` is a prop of the returned composite
 component. This is done to catch common causes of errors but, in some cases, the
 check could fail even if the ref is correctly forwarded to the root DOM
-component. In these cases, you can provide the object `{suppressRefError :
-true}` as the second argument to `getRootProps` to completely bypass the check.\
+component. In these cases, you can provide the object `{suppressRefError : true}` as the second argument to `getRootProps` to completely bypass the check.\
 **Please use it with extreme care and only if you are absolutely sure that the ref
 is correctly forwarded otherwise `Downshift` will unexpectedly fail.**\
 See issue paypal/downshift#235 for the discussion that lead to this.
@@ -755,7 +751,7 @@ Thanks goes to these people ([emoji key][emojis]):
 | [<img src="https://avatars1.githubusercontent.com/u/8969456?v=4" width="100px;"/><br /><sub><b>Paul Veevers</b></sub>](https://github.com/paul-veevers)<br />[💻](https://github.com/paypal/downshift/commits?author=paul-veevers "Code") | [<img src="https://avatars2.githubusercontent.com/u/13622298?v=4" width="100px;"/><br /><sub><b>Ron Cruz</b></sub>](https://github.com/Ronolibert)<br />[📖](https://github.com/paypal/downshift/commits?author=Ronolibert "Documentation") | [<img src="https://avatars1.githubusercontent.com/u/13605633?v=4" width="100px;"/><br /><sub><b>Rick McGavin</b></sub>](http://rickmcgavin.github.io)<br />[📖](https://github.com/paypal/downshift/commits?author=rickMcGavin "Documentation") | [<img src="https://avatars0.githubusercontent.com/u/869669?v=4" width="100px;"/><br /><sub><b>Jelle Versele</b></sub>](http://twitter.com/vejersele)<br />[💡](#example-vejersele "Examples") | [<img src="https://avatars1.githubusercontent.com/u/202773?v=4" width="100px;"/><br /><sub><b>Brent Ertz</b></sub>](https://github.com/brentertz)<br />[🤔](#ideas-brentertz "Ideas, Planning, & Feedback") | [<img src="https://avatars3.githubusercontent.com/u/8015514?v=4" width="100px;"/><br /><sub><b>Justice Mba </b></sub>](https://github.com/Dajust)<br />[💻](https://github.com/paypal/downshift/commits?author=Dajust "Code") [📖](https://github.com/paypal/downshift/commits?author=Dajust "Documentation") [🤔](#ideas-Dajust "Ideas, Planning, & Feedback") | [<img src="https://avatars2.githubusercontent.com/u/3925281?v=4" width="100px;"/><br /><sub><b>Mark Ellis</b></sub>](http://mfellis.com)<br />[🤔](#ideas-ellismarkf "Ideas, Planning, & Feedback") |
 | [<img src="https://avatars1.githubusercontent.com/u/3241922?v=4" width="100px;"/><br /><sub><b>us͡an̸df͘rien͜ds͠</b></sub>](http://ronak.io/)<br />[🐛](https://github.com/paypal/downshift/issues?q=author%3Ausandfriends "Bug reports") [💻](https://github.com/paypal/downshift/commits?author=usandfriends "Code") [⚠️](https://github.com/paypal/downshift/commits?author=usandfriends "Tests") | [<img src="https://avatars0.githubusercontent.com/u/474248?v=4" width="100px;"/><br /><sub><b>Robin Drexler</b></sub>](https://www.robin-drexler.com/)<br />[🐛](https://github.com/paypal/downshift/issues?q=author%3Arobin-drexler "Bug reports") [💻](https://github.com/paypal/downshift/commits?author=robin-drexler "Code") | [<img src="https://avatars0.githubusercontent.com/u/7406639?v=4" width="100px;"/><br /><sub><b>Arturo Romero</b></sub>](http://arturoromero.info/)<br />[💡](#example-arturoromeroslc "Examples") | [<img src="https://avatars1.githubusercontent.com/u/275483?v=4" width="100px;"/><br /><sub><b>yp</b></sub>](http://algolab.eu/pirola)<br />[🐛](https://github.com/paypal/downshift/issues?q=author%3Ayp "Bug reports") [💻](https://github.com/paypal/downshift/commits?author=yp "Code") [⚠️](https://github.com/paypal/downshift/commits?author=yp "Tests") | [<img src="https://avatars0.githubusercontent.com/u/3998604?v=4" width="100px;"/><br /><sub><b>Dave Garwacke</b></sub>](http://www.warbyparker.com)<br />[📖](https://github.com/paypal/downshift/commits?author=ifyoumakeit "Documentation") | [<img src="https://avatars3.githubusercontent.com/u/11758660?v=4" width="100px;"/><br /><sub><b>Ivan Pazhitnykh</b></sub>](http://linkedin.com/in/drapegnik)<br />[💻](https://github.com/paypal/downshift/commits?author=Drapegnik "Code") [⚠️](https://github.com/paypal/downshift/commits?author=Drapegnik "Tests") | [<img src="https://avatars0.githubusercontent.com/u/61776?v=4" width="100px;"/><br /><sub><b>Luis Merino</b></sub>](https://github.com/Rendez)<br />[📖](https://github.com/paypal/downshift/commits?author=Rendez "Documentation") |
 | [<img src="https://avatars0.githubusercontent.com/u/8746094?v=4" width="100px;"/><br /><sub><b>Andrew Hansen</b></sub>](http://twitter.com/arahansen)<br />[💻](https://github.com/paypal/downshift/commits?author=arahansen "Code") [⚠️](https://github.com/paypal/downshift/commits?author=arahansen "Tests") [🤔](#ideas-arahansen "Ideas, Planning, & Feedback") | [<img src="https://avatars3.githubusercontent.com/u/20307225?v=4" width="100px;"/><br /><sub><b>John Whiles</b></sub>](http://www.johnwhiles.com)<br />[💻](https://github.com/paypal/downshift/commits?author=Jwhiles "Code") | [<img src="https://avatars1.githubusercontent.com/u/1288694?v=4" width="100px;"/><br /><sub><b>Justin Hall</b></sub>](https://github.com/wKovacs64)<br />[🚇](#infra-wKovacs64 "Infrastructure (Hosting, Build-Tools, etc)") | [<img src="https://avatars2.githubusercontent.com/u/7641760?v=4" width="100px;"/><br /><sub><b>Pete Nykänen</b></sub>](https://twitter.com/pete_tnt)<br />[👀](#review-petetnt "Reviewed Pull Requests") | [<img src="https://avatars2.githubusercontent.com/u/4060187?v=4" width="100px;"/><br /><sub><b>Jared Palmer</b></sub>](http://jaredpalmer.com)<br />[💻](https://github.com/paypal/downshift/commits?author=jaredpalmer "Code") | [<img src="https://avatars3.githubusercontent.com/u/11477718?v=4" width="100px;"/><br /><sub><b>Philip Young</b></sub>](http://www.philipyoungg.com)<br />[💻](https://github.com/paypal/downshift/commits?author=philipyoungg "Code") [⚠️](https://github.com/paypal/downshift/commits?author=philipyoungg "Tests") [🤔](#ideas-philipyoungg "Ideas, Planning, & Feedback") | [<img src="https://avatars3.githubusercontent.com/u/8997319?v=4" width="100px;"/><br /><sub><b>Alexander Nanberg</b></sub>](https://alexandernanberg.com)<br />[📖](https://github.com/paypal/downshift/commits?author=alexandernanberg "Documentation") |
-| [<img src="https://avatars2.githubusercontent.com/u/1556430?v=4" width="100px;"/><br /><sub><b>Pete Redmond</b></sub>](https://httpete.com)<br />[🐛](https://github.com/paypal/downshift/issues?q=author%3Ahttpete-ire "Bug reports") | [<img src="https://avatars2.githubusercontent.com/u/1706342?v=4" width="100px;"/><br /><sub><b>Nick Lavin</b></sub>](https://github.com/Zashy)<br />[🐛](https://github.com/paypal/downshift/issues?q=author%3AZashy "Bug reports") [💻](https://github.com/paypal/downshift/commits?author=Zashy "Code") [⚠️](https://github.com/paypal/downshift/commits?author=Zashy "Tests") |
+| [<img src="https://avatars2.githubusercontent.com/u/1556430?v=4" width="100px;"/><br /><sub><b>Pete Redmond</b></sub>](https://httpete.com)<br />[🐛](https://github.com/paypal/downshift/issues?q=author%3Ahttpete-ire "Bug reports") | [<img src="https://avatars2.githubusercontent.com/u/1706342?v=4" width="100px;"/><br /><sub><b>Nick Lavin</b></sub>](https://github.com/Zashy)<br />[🐛](https://github.com/paypal/downshift/issues?q=author%3AZashy "Bug reports") [💻](https://github.com/paypal/downshift/commits?author=Zashy "Code") [⚠️](https://github.com/paypal/downshift/commits?author=Zashy "Tests") | [<img src="https://avatars2.githubusercontent.com/u/17031?v=4" width="100px;"/><br /><sub><b>James Long</b></sub>](http://jlongster.com)<br />[🐛](https://github.com/paypal/downshift/issues?q=author%3Ajlongster "Bug reports") [💻](https://github.com/paypal/downshift/commits?author=jlongster "Code") |
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 

--- a/src/__mocks__/utils.js
+++ b/src/__mocks__/utils.js
@@ -1,0 +1,4 @@
+const actualUtils = require.requireActual('../utils')
+module.exports = Object.assign(actualUtils, {
+  scrollIntoView: jest.fn(), // hard to write tests for this thing...
+})

--- a/src/__tests__/downshift.misc-with-utils-mocked.js
+++ b/src/__tests__/downshift.misc-with-utils-mocked.js
@@ -1,0 +1,52 @@
+// this is stuff that I couldn't think fit anywhere else
+// but we still want to have tested.
+
+import React from 'react'
+import {mount} from 'enzyme'
+import Downshift from '../'
+import {scrollIntoView} from '../utils'
+
+jest.useFakeTimers()
+jest.mock('../utils')
+
+test('does not scroll from an onMouseEnter event', () => {
+  class HighlightedIndexController extends React.Component {
+    state = {highlightedIndex: 10}
+    handleStateChange = changes => {
+      if (changes.hasOwnProperty('highlightedIndex')) {
+        this.setState({highlightedIndex: changes.highlightedIndex})
+      }
+    }
+    render() {
+      return (
+        <Downshift
+          onStateChange={this.handleStateChange}
+          highlightedIndex={this.state.highlightedIndex}
+          render={({getInputProps, getItemProps}) => (
+            <div>
+              <input {...getInputProps()} />
+              <div {...getItemProps({item: 'hi', 'data-test': 'item-1'})} />
+              <div {...getItemProps({item: 'hey', 'data-test': 'item-2'})} />
+            </div>
+          )}
+        />
+      )
+    }
+  }
+  const wrapper = mount(<HighlightedIndexController />)
+  const input = wrapper.find('input')
+  const item = wrapper.find(sel('item-1'))
+  item.simulate('mouseenter')
+  jest.runAllTimers()
+  expect(scrollIntoView).not.toHaveBeenCalled()
+  // now let's make sure that we can still scroll items into view
+  // ↓
+  input.simulate('keydown', {key: 'ArrowDown'})
+  expect(scrollIntoView).toHaveBeenCalled()
+})
+
+function sel(id) {
+  return `[data-test="${id}"]`
+}
+
+/* eslint no-console:0 */

--- a/src/__tests__/downshift.props.js
+++ b/src/__tests__/downshift.props.js
@@ -129,7 +129,6 @@ test('uses given environment', () => {
   wrapper.unmount()
   expect(environment.addEventListener).toHaveBeenCalledTimes(2)
   expect(environment.removeEventListener).toHaveBeenCalledTimes(2)
-  expect(environment.document.getElementById).toHaveBeenCalledTimes(1)
 })
 
 test('can override onOuterClick callback to maintain isOpen state', () => {

--- a/src/__tests__/utils.scroll-into-view.js
+++ b/src/__tests__/utils.scroll-into-view.js
@@ -129,18 +129,16 @@ function getScrollableNode(overrides = {}) {
   })
 }
 
-function getNode(
-  {
-    top = 0,
-    height = 0,
-    scrollTop = 0,
-    scrollHeight = height,
-    clientHeight = height,
-    children = [],
-    borderBottomWidth = 0,
-    borderTopWidth = 0,
-  } = {},
-) {
+function getNode({
+  top = 0,
+  height = 0,
+  scrollTop = 0,
+  scrollHeight = height,
+  clientHeight = height,
+  children = [],
+  borderBottomWidth = 0,
+  borderTopWidth = 0,
+} = {}) {
   const div = document.createElement('div')
   div.getBoundingClientRect = () => ({
     width: 50,

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -827,12 +827,10 @@ class Downshift extends Component {
       })
     }
 
-    const current = this.isControlledProp('highlightedIndex')
-      ? this.props
-      : this.state
-    const prev = this.isControlledProp('highlightedIndex')
-      ? prevProps
-      : prevState
+    const current =
+      this.props.highlightedIndex === undefined ? this.state : this.props
+    const prev =
+      prevProps.highlightedIndex === undefined ? prevState : prevProps
 
     if (
       current.highlightedIndex !== prev.highlightedIndex &&


### PR DESCRIPTION
Fixes #281. 

As I dug into this I realized that it would be nicer to consolidate the code for scrolling to an item so it behaves exactly the same whether or not you are controlling the prop. This will reduce bugs between those use cases.

The way to do this is to always scroll within `componentDidUpdate`. The only problem is that this makes it harder to control scrolling; my first attempt added an option to `setHighlightedIndex` to avoid scrolling, and since that's called directly from `onMouseEvent` we can pass that information. But in `componentDidUpdate` we have no idea why it's changing. However this is always the case in the controlled prop scenario anyway, so we have to accept it.

The only solution is an ugly setTimeout which tells the system to not scroll it at all. This nicely fixes the problem entirely; it'll never scroll it if you are moving the cursor around or scrolling yourself and makes it feel a lot better. Note that this also changes the uncontrolled prop scenario: if you hover over an element at the bottom of the list, **it will no longer scroll down** to show it fully in view. This is better behavior in my opinion though as I'd never expect it to move around under me just by hovering.

This does not fix #240, as it's a different issue caused by a similar `onMouseEnter` event. A similar fix could be adopted there where it sets a timeout to tell the system to avoid any `onMouseEnter` events after key up/down.

**Checklist**:

* [ ] Documentation NA
* [x] Tests
* [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [x] Added myself to contributors table
