### PR TITLE
[bug][hotfix] Fix focusInput() by using getElementById

### DIFF
--- a/src/__tests__/downshift.focus-text-input.js
+++ b/src/__tests__/downshift.focus-text-input.js
@@ -14,11 +14,14 @@ test('input is focused upon item mouse click', () => {
 })
 
 function getWrapper(items) {
+  const id="languages[0].name";
+
   return mount(
     <Downshift
+      id={id}
       render={({getInputProps, getItemProps}) => (
         <div>
-          <input {...getInputProps()} />
+          <input {...getInputProps({ id })} />
           <div>
             {items.map(item => (
               <div data-test={item} key={item} {...getItemProps({item})}>

--- a/src/__tests__/downshift.focus-text-input.js
+++ b/src/__tests__/downshift.focus-text-input.js
@@ -14,14 +14,14 @@ test('input is focused upon item mouse click', () => {
 })
 
 function getWrapper(items) {
-  const id="languages[0].name";
+  const id = 'languages[0].name'
 
   return mount(
     <Downshift
       id={id}
       render={({getInputProps, getItemProps}) => (
         <div>
-          <input {...getInputProps({ id })} />
+          <input {...getInputProps({id})} />
           <div>
             {items.map(item => (
               <div data-test={item} key={item} {...getItemProps({item})}>

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -273,7 +273,7 @@ class Downshift extends Component {
   }
 
   focusInput() {
-    const inputNode = this._rootNode.getElementById(this.inputId)
+    const inputNode = this._rootNode.querySelector(`[id="${this.inputId}"]`)
     inputNode && inputNode.focus && inputNode.focus()
   }
 

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -273,7 +273,7 @@ class Downshift extends Component {
   }
 
   focusInput() {
-    const inputNode = this._rootNode.querySelector(`#${this.inputId}`)
+    const inputNode = this._rootNode.getElementById(this.inputId)
     inputNode && inputNode.focus && inputNode.focus()
   }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Updated querSelector to use escaped selector

<!-- Why are these changes necessary? -->

**Why**:

Because if my id is "fields[0].name" then focusInput throw an exception

<!-- How were these changes implemented? -->

**How**:

easily, I just used my keyboard (and my fingers)

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [x] Tests
* [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
