### PR TITLE
Added clarification to onOuterClick description

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,8 @@ const ui = (
 )
 ```
 
+This callback will only be called if `isOpen` is `true`.
+
 ## Control Props
 
 downshift manages its own state internally and calls your `onChange` and


### PR DESCRIPTION
**What**:

Updated documentation to show that `onOuterClick` is only fired when `isOpen` is true. (See #311)

**Why**:

This tripped me up a little bit when I was trying to use it.


**Checklist**:

* [x] Documentation
* [ ] Tests – N/A
* [x] Ready to be merged
* [ ] Added myself to contributors table

