### PR TITLE
Correct `redux-final-form` to `react-final-form`

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,7 +703,7 @@ Examples exist on [codesandbox.io][examples]:
   the state, actions, prop getters in a rendered downshift tree).
 * [Downshift Spectre.css example](https://codesandbox.io/s/M89KQOBRB)
 * [Integration with `redux-form`](https://codesandbox.io/s/k594964z13)
-* [Integration with `redux-final-form`](https://codesandbox.io/s/qzm43nn2mj)
+* [Integration with `react-final-form`](https://codesandbox.io/s/qzm43nn2mj)
 * [Provider Pattern](https://codesandbox.io/s/mywzk3133p) - how to avoid prop-drilling if you like to break up your render method into more components
 
 If you would like to add an example, follow these steps:


### PR DESCRIPTION
It's not `redux-final-form`

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
The `react-final-form` library was wrongly referenced as `redux-final-form`
<!-- Why are these changes necessary? -->

**Why**:
Just changed the anchor link to `react-final-form`
<!-- How were these changes implemented? -->

**How**:
N/A
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [ ] Tests N/A
* [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
