### PR TITLE
fix(generateId): fix initial idCounter and use single unique id for a Downshift instance

### DIFF
--- a/src/__tests__/utils.reset-id-counter.js
+++ b/src/__tests__/utils.reset-id-counter.js
@@ -3,10 +3,6 @@ import {mount} from 'enzyme'
 import Downshift from '../'
 import {resetIdCounter} from '../utils'
 
-test('does not throw', () => {
-  expect(() => resetIdCounter()).not.toThrow()
-})
-
 test('renders with correct and predictable auto generated id upon resetIdCounter call', () => {
   resetIdCounter()
 

--- a/src/__tests__/utils.reset-id-counter.js
+++ b/src/__tests__/utils.reset-id-counter.js
@@ -10,35 +10,51 @@ test('does not throw', () => {
 test('renders with correct and predictable auto generated id upon resetIdCounter call', () => {
   resetIdCounter()
 
-  const render = ({getInputProps, getLabelProps}) => (
+  const render = ({getInputProps, getLabelProps, getItemProps}) => (
     <div>
       <label {...getLabelProps()} />
       <input {...getInputProps()} />
+      <div>
+        <span
+          {...getItemProps({
+            item: 0,
+            'data-test': 'item-0',
+          })}
+        >
+          0
+        </span>
+      </div>
     </div>
   )
 
   const {id, wrapper} = setup({render})
   const label = wrapper.find('label').first()
   const input = wrapper.find('input').first()
+  const item = wrapper.find('[data-test="item-0"]').first()
   expect(id).toBe('downshift-0')
-  expect(label.instance().getAttribute('for')).toBe('downshift-input-0')
-  expect(input.instance().getAttribute('id')).toBe('downshift-input-0')
+  expect(label.instance().getAttribute('for')).toBe('downshift-0-input')
+  expect(input.instance().getAttribute('id')).toBe('downshift-0-input')
+  expect(item.instance().getAttribute('id')).toBe('downshift-0-item-0')
 
   const {id: id2, wrapper: wrapper2} = setup({render})
   const label2 = wrapper2.find('label').first()
   const input2 = wrapper2.find('input').first()
+  const item2 = wrapper2.find('[data-test="item-0"]').first()
   expect(id2).toBe('downshift-1')
-  expect(label2.instance().getAttribute('for')).toBe('downshift-input-1')
-  expect(input2.instance().getAttribute('id')).toBe('downshift-input-1')
+  expect(label2.instance().getAttribute('for')).toBe('downshift-1-input')
+  expect(input2.instance().getAttribute('id')).toBe('downshift-1-input')
+  expect(item2.instance().getAttribute('id')).toBe('downshift-1-item-0')
 
   resetIdCounter()
 
   const {id: id3, wrapper: wrapper3} = setup({render})
   const label3 = wrapper3.find('label').first()
   const input3 = wrapper3.find('input').first()
+  const item3 = wrapper3.find('[data-test="item-0"]').first()
   expect(id3).toBe('downshift-0')
-  expect(label3.instance().getAttribute('for')).toBe('downshift-input-0')
-  expect(input3.instance().getAttribute('id')).toBe('downshift-input-0')
+  expect(label3.instance().getAttribute('for')).toBe('downshift-0-input')
+  expect(input3.instance().getAttribute('id')).toBe('downshift-0-input')
+  expect(item3.instance().getAttribute('id')).toBe('downshift-0-item-0')
 })
 
 function setup({render = () => <div />, ...props} = {}) {

--- a/src/__tests__/utils.reset-id-counter.js
+++ b/src/__tests__/utils.reset-id-counter.js
@@ -1,5 +1,52 @@
+import React from 'react'
+import {mount} from 'enzyme'
+import Downshift from '../'
 import {resetIdCounter} from '../utils'
 
 test('does not throw', () => {
   expect(() => resetIdCounter()).not.toThrow()
 })
+
+test('renders with correct and predictable auto generated id upon resetIdCounter call', () => {
+  resetIdCounter()
+
+  const render = ({getInputProps, getLabelProps}) => (
+    <div>
+      <label {...getLabelProps()} />
+      <input {...getInputProps()} />
+    </div>
+  )
+
+  const {id, wrapper} = setup({render})
+  const label = wrapper.find('label').first()
+  const input = wrapper.find('input').first()
+  expect(id).toBe('downshift-0')
+  expect(label.instance().getAttribute('for')).toBe('downshift-input-0')
+  expect(input.instance().getAttribute('id')).toBe('downshift-input-0')
+
+  const {id: id2, wrapper: wrapper2} = setup({render})
+  const label2 = wrapper2.find('label').first()
+  const input2 = wrapper2.find('input').first()
+  expect(id2).toBe('downshift-1')
+  expect(label2.instance().getAttribute('for')).toBe('downshift-input-1')
+  expect(input2.instance().getAttribute('id')).toBe('downshift-input-1')
+
+  resetIdCounter()
+
+  const {id: id3, wrapper: wrapper3} = setup({render})
+  const label3 = wrapper3.find('label').first()
+  const input3 = wrapper3.find('input').first()
+  expect(id3).toBe('downshift-0')
+  expect(label3.instance().getAttribute('for')).toBe('downshift-input-0')
+  expect(input3.instance().getAttribute('id')).toBe('downshift-input-0')
+})
+
+function setup({render = () => <div />, ...props} = {}) {
+  let renderArg
+  const renderSpy = jest.fn(controllerArg => {
+    renderArg = controllerArg
+    return render(controllerArg)
+  })
+  const wrapper = mount(<Downshift {...props} render={renderSpy} />)
+  return {wrapper, ...renderArg}
+}

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -128,8 +128,7 @@ class Downshift extends Component {
       state.inputValue = this.props.itemToString(state.selectedItem)
     }
     this.state = state
-    this.uniqueId = generateId()
-    this.id = this.props.id || `downshift-${this.uniqueId}`
+    this.id = this.props.id || `downshift-${generateId()}`
   }
 
   input = null

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -10,7 +10,6 @@ import {
   debounce,
   scrollIntoView,
   generateId,
-  getPrefixedId,
   firstDefined,
   getA11yStatusMessage,
   unwrapArray,
@@ -130,7 +129,7 @@ class Downshift extends Component {
     }
     this.state = state
     this.uniqueId = generateId()
-    this.id = this.props.id || getPrefixedId('downshift', this.uniqueId)
+    this.id = this.props.id || `downshift-${this.uniqueId}`
   }
 
   input = null
@@ -601,11 +600,7 @@ class Downshift extends Component {
         }". You must either remove the id from your input or set the htmlFor of the label equal to the input id.`,
       )
     }
-    this.inputId = firstDefined(
-      this.inputId,
-      props.htmlFor,
-      getPrefixedId('downshift-input', this.uniqueId),
-    )
+    this.inputId = firstDefined(this.inputId, props.htmlFor, `${this.id}-input`)
     return {
       ...props,
       htmlFor: this.inputId,
@@ -627,11 +622,7 @@ class Downshift extends Component {
         }". You must either remove the id from your input or set the htmlFor of the label equal to the input id.`,
       )
     }
-    this.inputId = firstDefined(
-      this.inputId,
-      rest.id,
-      getPrefixedId('downshift-input', this.uniqueId),
-    )
+    this.inputId = firstDefined(this.inputId, rest.id, `${this.id}-input`)
     let onChangeKey
     /* istanbul ignore next (preact) */
     if (preval`module.exports = process.env.BUILD_PREACT === 'true'`) {

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -10,6 +10,7 @@ import {
   debounce,
   scrollIntoView,
   generateId,
+  getPrefixedId,
   firstDefined,
   getA11yStatusMessage,
   unwrapArray,
@@ -69,7 +70,6 @@ class Downshift extends Component {
     defaultInputValue: '',
     defaultIsOpen: false,
     getA11yStatusMessage,
-    id: generateId('downshift'),
     itemToString: i => {
       if (i == null) {
         return ''
@@ -129,6 +129,8 @@ class Downshift extends Component {
       state.inputValue = this.props.itemToString(state.selectedItem)
     }
     this.state = state
+    this.uniqueId = generateId()
+    this.id = this.props.id || getPrefixedId('downshift', this.uniqueId)
   }
 
   input = null
@@ -409,7 +411,8 @@ class Downshift extends Component {
 
   getStateAndHelpers() {
     const {highlightedIndex, inputValue, selectedItem, isOpen} = this.getState()
-    const {id, itemToString} = this.props
+    const {itemToString} = this.props
+    const {id} = this
     const {
       getRootProps,
       getButtonProps,
@@ -453,6 +456,8 @@ class Downshift extends Component {
 
       //props
       itemToString,
+
+      //derived
       id,
 
       // state
@@ -599,7 +604,7 @@ class Downshift extends Component {
     this.inputId = firstDefined(
       this.inputId,
       props.htmlFor,
-      generateId('downshift-input'),
+      getPrefixedId('downshift-input', this.uniqueId),
     )
     return {
       ...props,
@@ -625,7 +630,7 @@ class Downshift extends Component {
     this.inputId = firstDefined(
       this.inputId,
       rest.id,
-      generateId('downshift-input'),
+      getPrefixedId('downshift-input', this.uniqueId),
     )
     let onChangeKey
     /* istanbul ignore next (preact) */
@@ -692,7 +697,7 @@ class Downshift extends Component {
 
   /////////////////////////////// ITEM
   getItemId(index) {
-    return `${this.props.id}-item-${index}`
+    return `${this.id}-item-${index}`
   }
 
   getItemProps = ({

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-let idCounter = 1
+let idCounter = 0
 
 /**
  * Accepts a parameter and returns it if it's a function
@@ -146,12 +146,21 @@ function composeEventHandlers(...fns) {
 }
 
 /**
- * This generates a unique ID for all autocomplete inputs
- * @param {String} prefix the prefix for the id
+ * This generates a unique ID for an instance of Downshift
  * @return {String} the unique ID
  */
-function generateId(prefix) {
-  return `${prefix}-${idCounter++}`
+function generateId() {
+  return `${idCounter++}`
+}
+
+/**
+ * This generates a prefixed id used for different components inside Downshift
+ * @param {String} prefix the prefix for the id
+ * @param {String} id the unique ID
+ * @return {String} the prefixed unique ID
+ */
+function getPrefixedId(prefix, id) {
+  return `${prefix}-${id}`
 }
 
 /**
@@ -283,6 +292,7 @@ export {
   scrollIntoView,
   findParent,
   generateId,
+  getPrefixedId,
   firstDefined,
   getA11yStatusMessage,
   unwrapArray,

--- a/src/utils.js
+++ b/src/utils.js
@@ -150,7 +150,7 @@ function composeEventHandlers(...fns) {
  * @return {String} the unique ID
  */
 function generateId() {
-  return `${idCounter++}`
+  return String(idCounter++)
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -154,16 +154,6 @@ function generateId() {
 }
 
 /**
- * This generates a prefixed id used for different components inside Downshift
- * @param {String} prefix the prefix for the id
- * @param {String} id the unique ID
- * @return {String} the prefixed unique ID
- */
-function getPrefixedId(prefix, id) {
-  return `${prefix}-${id}`
-}
-
-/**
  * This is only used in tests
  * @param {Number} num The number to set the idCounter to
  */
@@ -292,7 +282,6 @@ export {
   scrollIntoView,
   findParent,
   generateId,
-  getPrefixedId,
   firstDefined,
   getA11yStatusMessage,
   unwrapArray,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

This fixes mismatch in client side and SSR generated Id and ensure that Downshift instance is tagged with a single unique id.

<!-- Why are these changes necessary? -->

**Why**:

Refer to https://github.com/paypal/downshift/issues/340

<!-- How were these changes implemented? -->

**How**:

* Set the initial `idCounter` to 0 instead of 1 to match it with `resetIdCounter` call.
* Use `id` to construct all generated ids

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [x] Tests
* [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
