### PR TITLE
Add keyDownHandlers prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ harder to contribute to.
   * [onSelect](#onselect)
   * [onStateChange](#onstatechange)
   * [stateReducer](#statereducer)
+  * [keyDownHandlers](#keydownhandlers)
   * [onInputValueChange](#oninputvaluechange)
   * [itemCount](#itemcount)
   * [highlightedIndex](#highlightedindex)
@@ -337,6 +338,31 @@ function stateReducer(state, changes) {
   }
 }
 ```
+
+### keyDownHandlers
+
+> `{ ...handlers }` | optional
+
+NOTE: Normally if you want to add keydown handlers to the button or input, you can simply pass `onKeyDown` to `getInputProps` and `getButtonProps` (respectively). However, if you want to override built-in handling of specific keys, you can use this prop.
+
+Also if you want to override the built-in behavior of _all_ the keys, you can add `event.preventDefault()` in your own handler and that will signal to downshift to skip it's built-in event handler.
+
+This prop allows you to use your own keydown handlers which can be handy if you want custom behavior. If a key and handler you pass is already defined in downshift, the custom handler you pass will be used instead.
+
+For example, if you create an Enter handler, this will not change the default behavior of the other keyDown events: ArrowUp, ArrowDown, and Escape.
+
+```jsx
+const handlers = {
+  Enter(event) {
+    // Custom behavior for ENTER keydown
+  },
+}
+
+const ui = <Downshift keyDownHandlers={handlers} />
+```
+
+⚠️ **This is an advanced feature and you should avoid using it** ⚠️
+This feature exposes the downshift instance in a way that could lead to your code breaking if we decide to change a method you are relying on.
 
 ### onInputValueChange
 

--- a/src/__tests__/downshift.props.js
+++ b/src/__tests__/downshift.props.js
@@ -218,6 +218,23 @@ test('stateReducer customizes the final state after keyDownEnter handled', () =>
   )
 })
 
+test('calls key handlers when keyDownHandlers is passed', () => {
+  const keyDownHandlers = {
+    Enter: jest.fn(),
+    Escape: jest.fn(),
+    ArrowUp: jest.fn(),
+    ArrowDown: jest.fn(),
+  }
+  const keyPresses = Object.keys(keyDownHandlers)
+  const render = ({getInputProps}) => <input {...getInputProps()} />
+  const {wrapper} = setup({render, keyDownHandlers})
+
+  keyPresses.forEach(key => {
+    wrapper.find('input').simulate('keyDown', {key})
+    expect(keyDownHandlers[key]).toHaveBeenCalled()
+  })
+})
+
 function mouseDownAndUp(node) {
   node.dispatchEvent(new window.MouseEvent('mousedown', {bubbles: true}))
   node.dispatchEvent(new window.MouseEvent('mouseup', {bubbles: true}))

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -31,6 +31,7 @@ class Downshift extends Component {
     defaultIsOpen: PropTypes.bool,
     getA11yStatusMessage: PropTypes.func,
     itemToString: PropTypes.func,
+    keyDownHandlers: PropTypes.object,
     onChange: PropTypes.func,
     onSelect: PropTypes.func,
     onStateChange: PropTypes.func,
@@ -84,6 +85,7 @@ class Downshift extends Component {
       }
       return String(i)
     },
+    keyDownHandlers: {},
     onStateChange: () => {},
     onInputValueChange: () => {},
     onUserAction: () => {},
@@ -423,6 +425,7 @@ class Downshift extends Component {
       selectItemAtIndex,
       selectHighlightedItem,
       setHighlightedIndex,
+      moveHighlightedIndex,
       clearSelection,
       clearItems,
       reset,
@@ -446,6 +449,7 @@ class Downshift extends Component {
       selectItemAtIndex,
       selectHighlightedItem,
       setHighlightedIndex,
+      moveHighlightedIndex,
       clearSelection,
       clearItems,
       setItemCount,
@@ -502,7 +506,7 @@ class Downshift extends Component {
     },
 
     Enter(event) {
-      if (this.getState().isOpen) {
+      if (this.isOpen) {
         event.preventDefault()
         this.selectHighlightedItem({
           type: Downshift.stateChangeTypes.keyDownEnter,
@@ -668,8 +672,10 @@ class Downshift extends Component {
   }
 
   input_handleKeyDown = event => {
-    if (event.key && this.keyDownHandlers[event.key]) {
-      this.keyDownHandlers[event.key].call(this, event)
+    const handler =
+      this.props.keyDownHandlers[event.key] || this.keyDownHandlers[event.key]
+    if (handler) {
+      handler.call(this.getStateAndHelpers(), event)
     }
   }
 


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Allow downshift to accept a new prop called `keyDownHandlers`. 

<!-- Why are these changes necessary? -->

**Why**: This can be useful when one wants to customize key down handler behavior. It allows users to address issues such as #330 and #336 by passing an handler object to the `keyDownHandlers` prop. For example, in #330 when downshift is wrapped in a `<form>`, pressing `ENTER` key should call the `<form>'`s onSubmit handler. This doesn't happen because internally, downshift calls `event.preventDefault()` - preventing the `<form>` from submitting.

By [passing a custom handler](https://github.com/paypal/downshift/issues/330#issuecomment-367159522) for `ENTER` key, we can use a handler which does not call `event.preventDefault()`. 

<!-- How were these changes implemented? -->

**How**: If `keyDownHandlers` is passed, the handlers in the object will be used when downshift handles a keyDown event. Specifically, the handler will be called in `input_handleKeyDown`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [ ] Ready to be merged
* [ ] Added myself to contributors table

P.S. Please let me know if something in this pull request isn't clear. I would love suggestions from the community as this is my first PR for Downshift! 

Thank you for reviewing this PR. Thanks @kentcdodds, @austintackaberry, @indiesquidge, and @newyork-anthonyng for having a conversation on issue #330. Thanks to @kentcdodds for coming up with a flexible solution ❤️.

