### PR TITLE
fix: set type Downshift.stateChangeTypes.clickItem on item click

### DIFF
--- a/src/downshift.js
+++ b/src/downshift.js
@@ -736,7 +736,9 @@ class Downshift extends Component {
         event.preventDefault()
       }),
       [onSelectKey]: composeEventHandlers(onClick, () => {
-        this.selectItemAtIndex(index)
+        this.selectItemAtIndex(index, {
+          type: Downshift.stateChangeTypes.clickItem,
+        })
       }),
       ...rest,
     }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Item click handler does not set `type: Downshift.stateChangeTypes.clickItem`. The bug was introduced from #265.

<!-- Why are these changes necessary? -->

**Why**: It breaks stateReducer in case `Downshift.stateChangeTypes.clickItem` is being used

<!-- How were these changes implemented? -->

**How**: I added back the missing code.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
