### PR TITLE
WIP: test coverage issues with onBlur

### DIFF
--- a/cypress/integration/basic.js
+++ b/cypress/integration/basic.js
@@ -64,4 +64,14 @@ describe('Basic', () => {
       .getInStoryByTestId('basic-input')
       .should('have.value', 'Red')
   })
+
+  it('resets when tabbing from input to button', () => {
+    cy
+      .getInStoryByTestId('basic-input')
+      .type('re')
+      .getInStoryByTestId('clear-selection')
+      .focus()
+      .getInStoryByTestId('downshift-item-0')
+      .should('not.be.visible')
+  })
 })

--- a/cypress/integration/semantic-ui.js
+++ b/cypress/integration/semantic-ui.js
@@ -1,0 +1,37 @@
+describe('Semantic-UI', () => {
+    before(() => {
+        cy.visitStory('semantic-ui')
+    })
+
+    beforeEach(() => {
+        cy.getInStoryByTestId('semantic-ui-input').type('{selectAll}{del}')
+    })
+
+    afterEach(() => {
+        cy.getInStoryByTestId('semantic-ui-clear-button').click()
+    })
+
+    it('does not reset when tabbing from input to button', () => {
+        cy
+            .getInStoryByTestId('semantic-ui-input')
+            .type('Alg')
+            .getInStoryByTestId('semantic-ui-toggle-button')
+            .focus()
+            .getInStoryByTestId('downshift-item-0')
+            .click()
+            .getInStoryByTestId('semantic-ui-input')
+            .should('have.value', 'Algeria')
+    })
+
+    it('does not reset when tabbing from button to input', () => {
+        cy
+            .getInStoryByTestId('semantic-ui-toggle-button')
+            .click()
+            .getInStoryByTestId('semantic-ui-input')
+            .focus()
+            .getInStoryByTestId('downshift-item-0')
+            .click()
+            .getInStoryByTestId('semantic-ui-input')
+            .should('have.value', 'Afghanistan')
+    })
+})

--- a/cypress/integration/semantic-ui.js
+++ b/cypress/integration/semantic-ui.js
@@ -1,37 +1,37 @@
 describe('Semantic-UI', () => {
-    before(() => {
-        cy.visitStory('semantic-ui')
-    })
+  before(() => {
+    cy.visitStory('semantic-ui')
+  })
 
-    beforeEach(() => {
-        cy.getInStoryByTestId('semantic-ui-input').type('{selectAll}{del}')
-    })
+  beforeEach(() => {
+    cy.getInStoryByTestId('semantic-ui-input').type('{selectAll}{del}')
+  })
 
-    afterEach(() => {
-        cy.getInStoryByTestId('semantic-ui-clear-button').click()
-    })
+  afterEach(() => {
+    cy.getInStoryByTestId('semantic-ui-clear-button').click()
+  })
 
-    it('does not reset when tabbing from input to button', () => {
-        cy
-            .getInStoryByTestId('semantic-ui-input')
-            .type('Alg')
-            .getInStoryByTestId('semantic-ui-toggle-button')
-            .focus()
-            .getInStoryByTestId('downshift-item-0')
-            .click()
-            .getInStoryByTestId('semantic-ui-input')
-            .should('have.value', 'Algeria')
-    })
+  it('does not reset when tabbing from input to button', () => {
+    cy
+      .getInStoryByTestId('semantic-ui-input')
+      .type('Alg')
+      .getInStoryByTestId('semantic-ui-toggle-button')
+      .focus()
+      .getInStoryByTestId('downshift-item-0')
+      .click()
+      .getInStoryByTestId('semantic-ui-input')
+      .should('have.value', 'Algeria')
+  })
 
-    it('does not reset when tabbing from button to input', () => {
-        cy
-            .getInStoryByTestId('semantic-ui-toggle-button')
-            .click()
-            .getInStoryByTestId('semantic-ui-input')
-            .focus()
-            .getInStoryByTestId('downshift-item-0')
-            .click()
-            .getInStoryByTestId('semantic-ui-input')
-            .should('have.value', 'Afghanistan')
-    })
+  it('does not reset when tabbing from button to input', () => {
+    cy
+      .getInStoryByTestId('semantic-ui-toggle-button')
+      .click()
+      .getInStoryByTestId('semantic-ui-input')
+      .focus()
+      .getInStoryByTestId('downshift-item-0')
+      .click()
+      .getInStoryByTestId('semantic-ui-input')
+      .should('have.value', 'Afghanistan')
+  })
 })

--- a/src/__tests__/downshift.get-button-props.js
+++ b/src/__tests__/downshift.get-button-props.js
@@ -33,9 +33,12 @@ test('button ignores key events it does not handle', () => {
   expect(renderSpy).not.toHaveBeenCalled()
 })
 
+jest.useFakeTimers()
+
 test('on button blur resets the state', () => {
   const {button, renderSpy} = setup()
   button.simulate('blur')
+  jest.runAllTimers()
   expect(renderSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({
       isOpen: false,
@@ -51,6 +54,7 @@ test('on button blur does not reset the state when the mouse is down', () => {
     new window.MouseEvent('mousedown', {bubbles: true}),
   )
   button.simulate('blur')
+  jest.runAllTimers()
   expect(renderSpy).not.toHaveBeenCalled()
 })
 

--- a/src/__tests__/downshift.get-input-props.js
+++ b/src/__tests__/downshift.get-input-props.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { mount } from 'enzyme'
+import {mount} from 'enzyme'
 import Downshift from '../'
 
 const colors = [
@@ -15,119 +15,119 @@ const colors = [
 ]
 
 test('manages arrow up and down behavior', () => {
-  const { Component, renderSpy } = setup()
+  const {Component, renderSpy} = setup()
   const wrapper = mount(<Component />)
   const input = wrapper.find(sel('input'))
   // ↓
-  input.simulate('keydown', { key: 'ArrowDown' })
+  input.simulate('keydown', {key: 'ArrowDown'})
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({ isOpen: true, highlightedIndex: null }),
+    expect.objectContaining({isOpen: true, highlightedIndex: null}),
   )
 
   // ↓
-  input.simulate('keydown', { key: 'ArrowDown' })
+  input.simulate('keydown', {key: 'ArrowDown'})
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({ highlightedIndex: 0 }),
+    expect.objectContaining({highlightedIndex: 0}),
   )
 
   // ↓
-  input.simulate('keydown', { key: 'ArrowDown' })
+  input.simulate('keydown', {key: 'ArrowDown'})
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({ highlightedIndex: 1 }),
+    expect.objectContaining({highlightedIndex: 1}),
   )
 
   // <Shift>↓
-  input.simulate('keydown', { key: 'ArrowDown', shiftKey: true })
+  input.simulate('keydown', {key: 'ArrowDown', shiftKey: true})
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({ highlightedIndex: 6 }),
+    expect.objectContaining({highlightedIndex: 6}),
   )
 
   // ↑
-  input.simulate('keydown', { key: 'ArrowUp' })
+  input.simulate('keydown', {key: 'ArrowUp'})
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({ highlightedIndex: 5 }),
+    expect.objectContaining({highlightedIndex: 5}),
   )
 
   // <Shift>↑
-  input.simulate('keydown', { key: 'ArrowUp', shiftKey: true })
+  input.simulate('keydown', {key: 'ArrowUp', shiftKey: true})
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({ highlightedIndex: 0 }),
+    expect.objectContaining({highlightedIndex: 0}),
   )
 
   // ↑
-  input.simulate('keydown', { key: 'ArrowUp' })
+  input.simulate('keydown', {key: 'ArrowUp'})
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({ highlightedIndex: colors.length - 1 }),
+    expect.objectContaining({highlightedIndex: colors.length - 1}),
   )
 
   // ↓
-  input.simulate('keydown', { key: 'ArrowDown' })
+  input.simulate('keydown', {key: 'ArrowDown'})
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({ highlightedIndex: 0 }),
+    expect.objectContaining({highlightedIndex: 0}),
   )
 })
 
 test('arrow key down events do nothing when no items are rendered', () => {
-  const { Component, renderSpy } = setup({ items: [] })
+  const {Component, renderSpy} = setup({items: []})
   const wrapper = mount(<Component />)
   const input = wrapper.find(sel('input'))
   // ↓↓
-  input.simulate('keydown', { key: 'ArrowDown' })
-  input.simulate('keydown', { key: 'ArrowDown' })
+  input.simulate('keydown', {key: 'ArrowDown'})
+  input.simulate('keydown', {key: 'ArrowDown'})
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({ highlightedIndex: null }),
+    expect.objectContaining({highlightedIndex: null}),
   )
 })
 
 test('arrow up on a closed menu opens the menu', () => {
-  const { Component, renderSpy } = setup()
+  const {Component, renderSpy} = setup()
   const wrapper = mount(<Component />)
   const input = wrapper.find(sel('input'))
   // ↑
-  input.simulate('keydown', { key: 'ArrowUp' })
+  input.simulate('keydown', {key: 'ArrowUp'})
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({ isOpen: true, highlightedIndex: null }),
+    expect.objectContaining({isOpen: true, highlightedIndex: null}),
   )
 
   // ↑
-  input.simulate('keydown', { key: 'ArrowUp' })
+  input.simulate('keydown', {key: 'ArrowUp'})
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({ highlightedIndex: colors.length - 1 }),
+    expect.objectContaining({highlightedIndex: colors.length - 1}),
   )
 })
 
 test('enter on an input with a closed menu does nothing', () => {
-  const { Component, renderSpy } = setup()
+  const {Component, renderSpy} = setup()
   const wrapper = mount(<Component />)
   const input = wrapper.find(sel('input'))
   // ENTER
   renderSpy.mockClear()
-  input.simulate('keydown', { key: 'Enter' })
+  input.simulate('keydown', {key: 'Enter'})
   // does not even rerender
   expect(renderSpy).not.toHaveBeenCalled()
 })
 
 test('enter on an input with an open menu does nothing without a highlightedIndex', () => {
-  const { Component, renderSpy } = setup()
+  const {Component, renderSpy} = setup()
   const wrapper = mount(<Component isOpen={true} />)
   const input = wrapper.find(sel('input'))
   // ENTER
   renderSpy.mockClear()
-  input.simulate('keydown', { key: 'Enter' })
+  input.simulate('keydown', {key: 'Enter'})
   // does not even rerender
   expect(renderSpy).not.toHaveBeenCalled()
 })
 
 test('enter on an input with an open menu and a highlightedIndex selects that item', () => {
-  const { Component, renderSpy } = setup()
+  const {Component, renderSpy} = setup()
   const onChange = jest.fn()
   const isOpen = true
   const wrapper = mount(<Component isOpen={isOpen} onChange={onChange} />)
   const input = wrapper.find(sel('input'))
   // ↓
-  input.simulate('keydown', { key: 'ArrowDown' })
+  input.simulate('keydown', {key: 'ArrowDown'})
   // ENTER
-  input.simulate('keydown', { key: 'Enter' })
+  input.simulate('keydown', {key: 'Enter'})
   expect(onChange).toHaveBeenCalledTimes(1)
   const newState = expect.objectContaining({
     selectedItem: colors[0],
@@ -140,11 +140,11 @@ test('enter on an input with an open menu and a highlightedIndex selects that it
 })
 
 test('escape on an input without a selection should reset downshift and close the menu', () => {
-  const { Component, renderSpy } = setup()
+  const {Component, renderSpy} = setup()
   const wrapper = mount(<Component />)
   const input = wrapper.find(sel('input'))
-  input.simulate('change', { target: { value: 'p' } })
-  input.simulate('keydown', { key: 'Escape' })
+  input.simulate('change', {target: {value: 'p'}})
+  input.simulate('keydown', {key: 'Escape'})
   expect(input.instance().value).toBe('')
   expect(renderSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({
@@ -155,8 +155,8 @@ test('escape on an input without a selection should reset downshift and close th
 })
 
 test('escape on an input with a selection should reset downshift and close the menu', () => {
-  const { input, renderSpy, items } = setupDownshiftWithState()
-  input.simulate('keydown', { key: 'Escape' })
+  const {input, renderSpy, items} = setupDownshiftWithState()
+  input.simulate('keydown', {key: 'Escape'})
   expect(renderSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({
       isOpen: false,
@@ -166,9 +166,12 @@ test('escape on an input with a selection should reset downshift and close the m
   )
 })
 
+jest.useFakeTimers()
+
 test('on input blur resets the state', () => {
-  const { input, renderSpy, items } = setupDownshiftWithState()
+  const {input, renderSpy, items} = setupDownshiftWithState()
   input.simulate('blur')
+  jest.runAllTimers()
   expect(renderSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({
       isOpen: false,
@@ -179,37 +182,47 @@ test('on input blur resets the state', () => {
 })
 
 test('on input blur does not reset the state when the mouse is down', () => {
-  const { input, renderSpy } = setupDownshiftWithState()
+  const {input, renderSpy} = setupDownshiftWithState()
   // mousedown somwhere
   document.body.dispatchEvent(
-    new window.MouseEvent('mousedown', { bubbles: true }),
+    new window.MouseEvent('mousedown', {bubbles: true}),
   )
   input.simulate('blur')
+  jest.runAllTimers()
+  expect(renderSpy).not.toHaveBeenCalled()
+})
+
+test('on input blur does not reset the state when new focus is on downshift button', () => {
+  const {input, renderSpy, button} = setupDownshiftWithState()
+  const buttonNode = button.getDOMNode()
+  input.simulate('blur')
+  buttonNode.focus()
+  jest.runAllTimers()
   expect(renderSpy).not.toHaveBeenCalled()
 })
 
 test('keydown of things that are not handled do nothing', () => {
   const modifiers = [undefined, 'Shift']
-  const { Component, renderSpy } = setup()
+  const {Component, renderSpy} = setup()
   const wrapper = mount(<Component />)
   const input = wrapper.find(sel('input'))
   renderSpy.mockClear()
   modifiers.forEach(key => {
-    input.simulate('keydown', { key })
+    input.simulate('keydown', {key})
   })
   // does not even rerender
   expect(renderSpy).not.toHaveBeenCalled()
 })
 
 test('highlightedIndex uses the given itemCount prop to determine the last index', () => {
-  const { Component, renderSpy } = setup()
+  const {Component, renderSpy} = setup()
   const itemCount = 200
   const wrapper = mount(<Component itemCount={itemCount} isOpen={true} />)
   const input = wrapper.find(sel('input'))
   // ↑
-  input.simulate('keydown', { key: 'ArrowUp' })
+  input.simulate('keydown', {key: 'ArrowUp'})
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({ highlightedIndex: itemCount - 1 }),
+    expect.objectContaining({highlightedIndex: itemCount - 1}),
   )
 })
 
@@ -219,7 +232,7 @@ test('itemCount can be set and unset asynchronously', () => {
     downshift = d
     return (
       <div>
-        <input {...d.getInputProps({ 'data-test': 'input' })} />
+        <input {...d.getInputProps({'data-test': 'input'})} />
       </div>
     )
   })
@@ -227,31 +240,31 @@ test('itemCount can be set and unset asynchronously', () => {
     <Downshift isOpen={true} render={renderSpy} itemCount={10} />,
   )
   const input = wrapper.find(sel('input'))
-  const up = () => input.simulate('keydown', { key: 'ArrowUp' })
-  const down = () => input.simulate('keydown', { key: 'ArrowDown' })
+  const up = () => input.simulate('keydown', {key: 'ArrowUp'})
+  const down = () => input.simulate('keydown', {key: 'ArrowDown'})
 
   downshift.setItemCount(100)
   up()
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({ highlightedIndex: 99 }),
+    expect.objectContaining({highlightedIndex: 99}),
   )
   down()
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({ highlightedIndex: 0 }),
+    expect.objectContaining({highlightedIndex: 0}),
   )
   downshift.setItemCount(40)
   up()
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({ highlightedIndex: 39 }),
+    expect.objectContaining({highlightedIndex: 39}),
   )
   down()
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({ highlightedIndex: 0 }),
+    expect.objectContaining({highlightedIndex: 0}),
   )
   downshift.unsetItemCount()
   up()
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({ highlightedIndex: 9 }),
+    expect.objectContaining({highlightedIndex: 9}),
   )
 })
 
@@ -259,12 +272,12 @@ test('Enter when there is no item at index 0 still selects the highlighted item'
   // test inspired by https://github.com/paypal/downshift/issues/119
   // use case is virtualized lists
   const items = [
-    { value: 'cat', index: 1 },
-    { value: 'dog', index: 2 },
-    { value: 'bird', index: 3 },
-    { value: 'cheetah', index: 4 },
+    {value: 'cat', index: 1},
+    {value: 'dog', index: 2},
+    {value: 'bird', index: 3},
+    {value: 'cheetah', index: 4},
   ]
-  const { Component, renderSpy } = setup({ items })
+  const {Component, renderSpy} = setup({items})
   const wrapper = mount(
     <Component
       itemToString={i => (i ? i.value : '')}
@@ -274,10 +287,10 @@ test('Enter when there is no item at index 0 still selects the highlighted item'
   )
   const input = wrapper.find(sel('input'))
   // ↓
-  input.simulate('keydown', { key: 'ArrowDown' })
+  input.simulate('keydown', {key: 'ArrowDown'})
   // ENTER
   renderSpy.mockClear()
-  input.simulate('keydown', { key: 'Enter' })
+  input.simulate('keydown', {key: 'Enter'})
   expect(renderSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({
       selectedItem: items[1],
@@ -290,15 +303,15 @@ test('Enter when there is no item at index 0 still selects the highlighted item'
 // so we have to get into the implementation details a little bit (unless we want to run these tests
 // in IE11... no thank you 🙅)
 test(`getInputProps doesn't include event handlers when disabled is passed (for IE11 support)`, () => {
-  const { getInputProps } = setupWithDownshiftController()
-  const props = getInputProps({ disabled: true })
+  const {getInputProps} = setupWithDownshiftController()
+  const props = getInputProps({disabled: true})
   const entry = Object.entries(props).find(
     ([_key, value]) => typeof value === 'function',
   )
   if (entry) {
     throw new Error(
       `getInputProps should not have any props that are callbacks. It has ${
-      entry[0]
+        entry[0]
       }.`,
     )
   }
@@ -306,42 +319,46 @@ test(`getInputProps doesn't include event handlers when disabled is passed (for 
 
 function setupDownshiftWithState() {
   const items = ['animal', 'bug', 'cat']
-  const { Component, renderSpy } = setup({ items })
+  const {Component, renderSpy} = setup({items})
   const wrapper = mount(<Component />)
   const input = wrapper.find(sel('input'))
+  const button = wrapper.find(sel('button'))
   input.simulate('keydown')
-  input.simulate('change', { target: { value: 'a' } })
+  input.simulate('change', {target: {value: 'a'}})
   // ↓
-  input.simulate('keydown', { key: 'ArrowDown' })
+  input.simulate('keydown', {key: 'ArrowDown'})
   // ENTER to select the first one
-  input.simulate('keydown', { key: 'Enter' })
+  input.simulate('keydown', {key: 'Enter'})
   expect(input.instance().value).toBe(items[0])
   // ↓
-  input.simulate('keydown', { key: 'ArrowDown' })
-  input.simulate('change', { target: { value: 'bu' } })
+  input.simulate('keydown', {key: 'ArrowDown'})
+  input.simulate('change', {target: {value: 'bu'}})
   renderSpy.mockClear()
-  return { renderSpy, input, items, wrapper }
+  return {renderSpy, input, button, items, wrapper}
 }
 
-function setup({ items = colors } = {}) {
+function setup({items = colors} = {}) {
   /* eslint-disable react/jsx-closing-bracket-location */
-  const renderSpy = jest.fn(({ isOpen, getInputProps, getItemProps }) => (
-    <div>
-      <input {...getInputProps({ 'data-test': 'input' })} />
-      {isOpen && (
-        <div>
-          {items.map((item, index) => (
-            <div
-              key={item.index || index}
-              {...getItemProps({ item, index: item.index || index })}
-            >
-              {item.value ? item.value : item}
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
-  ))
+  const renderSpy = jest.fn(
+    ({isOpen, getInputProps, getButtonProps, getItemProps}) => (
+      <div>
+        <input {...getInputProps({'data-test': 'input'})} />
+        <button {...getButtonProps({'data-test': 'button'})} />
+        {isOpen && (
+          <div>
+            {items.map((item, index) => (
+              <div
+                key={item.index || index}
+                {...getItemProps({item, index: item.index || index})}
+              >
+                {item.value ? item.value : item}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    ),
+  )
 
   function BasicDownshift(props) {
     return <Downshift {...props} render={renderSpy} />

--- a/src/__tests__/downshift.get-input-props.js
+++ b/src/__tests__/downshift.get-input-props.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import {mount} from 'enzyme'
+import { mount } from 'enzyme'
 import Downshift from '../'
 
 const colors = [
@@ -15,119 +15,119 @@ const colors = [
 ]
 
 test('manages arrow up and down behavior', () => {
-  const {Component, renderSpy} = setup()
+  const { Component, renderSpy } = setup()
   const wrapper = mount(<Component />)
   const input = wrapper.find(sel('input'))
   // ↓
-  input.simulate('keydown', {key: 'ArrowDown'})
+  input.simulate('keydown', { key: 'ArrowDown' })
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({isOpen: true, highlightedIndex: null}),
+    expect.objectContaining({ isOpen: true, highlightedIndex: null }),
   )
 
   // ↓
-  input.simulate('keydown', {key: 'ArrowDown'})
+  input.simulate('keydown', { key: 'ArrowDown' })
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({highlightedIndex: 0}),
+    expect.objectContaining({ highlightedIndex: 0 }),
   )
 
   // ↓
-  input.simulate('keydown', {key: 'ArrowDown'})
+  input.simulate('keydown', { key: 'ArrowDown' })
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({highlightedIndex: 1}),
+    expect.objectContaining({ highlightedIndex: 1 }),
   )
 
   // <Shift>↓
-  input.simulate('keydown', {key: 'ArrowDown', shiftKey: true})
+  input.simulate('keydown', { key: 'ArrowDown', shiftKey: true })
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({highlightedIndex: 6}),
+    expect.objectContaining({ highlightedIndex: 6 }),
   )
 
   // ↑
-  input.simulate('keydown', {key: 'ArrowUp'})
+  input.simulate('keydown', { key: 'ArrowUp' })
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({highlightedIndex: 5}),
+    expect.objectContaining({ highlightedIndex: 5 }),
   )
 
   // <Shift>↑
-  input.simulate('keydown', {key: 'ArrowUp', shiftKey: true})
+  input.simulate('keydown', { key: 'ArrowUp', shiftKey: true })
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({highlightedIndex: 0}),
+    expect.objectContaining({ highlightedIndex: 0 }),
   )
 
   // ↑
-  input.simulate('keydown', {key: 'ArrowUp'})
+  input.simulate('keydown', { key: 'ArrowUp' })
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({highlightedIndex: colors.length - 1}),
+    expect.objectContaining({ highlightedIndex: colors.length - 1 }),
   )
 
   // ↓
-  input.simulate('keydown', {key: 'ArrowDown'})
+  input.simulate('keydown', { key: 'ArrowDown' })
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({highlightedIndex: 0}),
+    expect.objectContaining({ highlightedIndex: 0 }),
   )
 })
 
 test('arrow key down events do nothing when no items are rendered', () => {
-  const {Component, renderSpy} = setup({items: []})
+  const { Component, renderSpy } = setup({ items: [] })
   const wrapper = mount(<Component />)
   const input = wrapper.find(sel('input'))
   // ↓↓
-  input.simulate('keydown', {key: 'ArrowDown'})
-  input.simulate('keydown', {key: 'ArrowDown'})
+  input.simulate('keydown', { key: 'ArrowDown' })
+  input.simulate('keydown', { key: 'ArrowDown' })
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({highlightedIndex: null}),
+    expect.objectContaining({ highlightedIndex: null }),
   )
 })
 
 test('arrow up on a closed menu opens the menu', () => {
-  const {Component, renderSpy} = setup()
+  const { Component, renderSpy } = setup()
   const wrapper = mount(<Component />)
   const input = wrapper.find(sel('input'))
   // ↑
-  input.simulate('keydown', {key: 'ArrowUp'})
+  input.simulate('keydown', { key: 'ArrowUp' })
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({isOpen: true, highlightedIndex: null}),
+    expect.objectContaining({ isOpen: true, highlightedIndex: null }),
   )
 
   // ↑
-  input.simulate('keydown', {key: 'ArrowUp'})
+  input.simulate('keydown', { key: 'ArrowUp' })
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({highlightedIndex: colors.length - 1}),
+    expect.objectContaining({ highlightedIndex: colors.length - 1 }),
   )
 })
 
 test('enter on an input with a closed menu does nothing', () => {
-  const {Component, renderSpy} = setup()
+  const { Component, renderSpy } = setup()
   const wrapper = mount(<Component />)
   const input = wrapper.find(sel('input'))
   // ENTER
   renderSpy.mockClear()
-  input.simulate('keydown', {key: 'Enter'})
+  input.simulate('keydown', { key: 'Enter' })
   // does not even rerender
   expect(renderSpy).not.toHaveBeenCalled()
 })
 
 test('enter on an input with an open menu does nothing without a highlightedIndex', () => {
-  const {Component, renderSpy} = setup()
+  const { Component, renderSpy } = setup()
   const wrapper = mount(<Component isOpen={true} />)
   const input = wrapper.find(sel('input'))
   // ENTER
   renderSpy.mockClear()
-  input.simulate('keydown', {key: 'Enter'})
+  input.simulate('keydown', { key: 'Enter' })
   // does not even rerender
   expect(renderSpy).not.toHaveBeenCalled()
 })
 
 test('enter on an input with an open menu and a highlightedIndex selects that item', () => {
-  const {Component, renderSpy} = setup()
+  const { Component, renderSpy } = setup()
   const onChange = jest.fn()
   const isOpen = true
   const wrapper = mount(<Component isOpen={isOpen} onChange={onChange} />)
   const input = wrapper.find(sel('input'))
   // ↓
-  input.simulate('keydown', {key: 'ArrowDown'})
+  input.simulate('keydown', { key: 'ArrowDown' })
   // ENTER
-  input.simulate('keydown', {key: 'Enter'})
+  input.simulate('keydown', { key: 'Enter' })
   expect(onChange).toHaveBeenCalledTimes(1)
   const newState = expect.objectContaining({
     selectedItem: colors[0],
@@ -140,11 +140,11 @@ test('enter on an input with an open menu and a highlightedIndex selects that it
 })
 
 test('escape on an input without a selection should reset downshift and close the menu', () => {
-  const {Component, renderSpy} = setup()
+  const { Component, renderSpy } = setup()
   const wrapper = mount(<Component />)
   const input = wrapper.find(sel('input'))
-  input.simulate('change', {target: {value: 'p'}})
-  input.simulate('keydown', {key: 'Escape'})
+  input.simulate('change', { target: { value: 'p' } })
+  input.simulate('keydown', { key: 'Escape' })
   expect(input.instance().value).toBe('')
   expect(renderSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({
@@ -155,8 +155,8 @@ test('escape on an input without a selection should reset downshift and close th
 })
 
 test('escape on an input with a selection should reset downshift and close the menu', () => {
-  const {input, renderSpy, items} = setupDownshiftWithState()
-  input.simulate('keydown', {key: 'Escape'})
+  const { input, renderSpy, items } = setupDownshiftWithState()
+  input.simulate('keydown', { key: 'Escape' })
   expect(renderSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({
       isOpen: false,
@@ -167,7 +167,7 @@ test('escape on an input with a selection should reset downshift and close the m
 })
 
 test('on input blur resets the state', () => {
-  const {input, renderSpy, items} = setupDownshiftWithState()
+  const { input, renderSpy, items } = setupDownshiftWithState()
   input.simulate('blur')
   expect(renderSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({
@@ -179,10 +179,10 @@ test('on input blur resets the state', () => {
 })
 
 test('on input blur does not reset the state when the mouse is down', () => {
-  const {input, renderSpy} = setupDownshiftWithState()
+  const { input, renderSpy } = setupDownshiftWithState()
   // mousedown somwhere
   document.body.dispatchEvent(
-    new window.MouseEvent('mousedown', {bubbles: true}),
+    new window.MouseEvent('mousedown', { bubbles: true }),
   )
   input.simulate('blur')
   expect(renderSpy).not.toHaveBeenCalled()
@@ -190,26 +190,26 @@ test('on input blur does not reset the state when the mouse is down', () => {
 
 test('keydown of things that are not handled do nothing', () => {
   const modifiers = [undefined, 'Shift']
-  const {Component, renderSpy} = setup()
+  const { Component, renderSpy } = setup()
   const wrapper = mount(<Component />)
   const input = wrapper.find(sel('input'))
   renderSpy.mockClear()
   modifiers.forEach(key => {
-    input.simulate('keydown', {key})
+    input.simulate('keydown', { key })
   })
   // does not even rerender
   expect(renderSpy).not.toHaveBeenCalled()
 })
 
 test('highlightedIndex uses the given itemCount prop to determine the last index', () => {
-  const {Component, renderSpy} = setup()
+  const { Component, renderSpy } = setup()
   const itemCount = 200
   const wrapper = mount(<Component itemCount={itemCount} isOpen={true} />)
   const input = wrapper.find(sel('input'))
   // ↑
-  input.simulate('keydown', {key: 'ArrowUp'})
+  input.simulate('keydown', { key: 'ArrowUp' })
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({highlightedIndex: itemCount - 1}),
+    expect.objectContaining({ highlightedIndex: itemCount - 1 }),
   )
 })
 
@@ -219,7 +219,7 @@ test('itemCount can be set and unset asynchronously', () => {
     downshift = d
     return (
       <div>
-        <input {...d.getInputProps({'data-test': 'input'})} />
+        <input {...d.getInputProps({ 'data-test': 'input' })} />
       </div>
     )
   })
@@ -227,31 +227,31 @@ test('itemCount can be set and unset asynchronously', () => {
     <Downshift isOpen={true} render={renderSpy} itemCount={10} />,
   )
   const input = wrapper.find(sel('input'))
-  const up = () => input.simulate('keydown', {key: 'ArrowUp'})
-  const down = () => input.simulate('keydown', {key: 'ArrowDown'})
+  const up = () => input.simulate('keydown', { key: 'ArrowUp' })
+  const down = () => input.simulate('keydown', { key: 'ArrowDown' })
 
   downshift.setItemCount(100)
   up()
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({highlightedIndex: 99}),
+    expect.objectContaining({ highlightedIndex: 99 }),
   )
   down()
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({highlightedIndex: 0}),
+    expect.objectContaining({ highlightedIndex: 0 }),
   )
   downshift.setItemCount(40)
   up()
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({highlightedIndex: 39}),
+    expect.objectContaining({ highlightedIndex: 39 }),
   )
   down()
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({highlightedIndex: 0}),
+    expect.objectContaining({ highlightedIndex: 0 }),
   )
   downshift.unsetItemCount()
   up()
   expect(renderSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({highlightedIndex: 9}),
+    expect.objectContaining({ highlightedIndex: 9 }),
   )
 })
 
@@ -259,12 +259,12 @@ test('Enter when there is no item at index 0 still selects the highlighted item'
   // test inspired by https://github.com/paypal/downshift/issues/119
   // use case is virtualized lists
   const items = [
-    {value: 'cat', index: 1},
-    {value: 'dog', index: 2},
-    {value: 'bird', index: 3},
-    {value: 'cheetah', index: 4},
+    { value: 'cat', index: 1 },
+    { value: 'dog', index: 2 },
+    { value: 'bird', index: 3 },
+    { value: 'cheetah', index: 4 },
   ]
-  const {Component, renderSpy} = setup({items})
+  const { Component, renderSpy } = setup({ items })
   const wrapper = mount(
     <Component
       itemToString={i => (i ? i.value : '')}
@@ -274,10 +274,10 @@ test('Enter when there is no item at index 0 still selects the highlighted item'
   )
   const input = wrapper.find(sel('input'))
   // ↓
-  input.simulate('keydown', {key: 'ArrowDown'})
+  input.simulate('keydown', { key: 'ArrowDown' })
   // ENTER
   renderSpy.mockClear()
-  input.simulate('keydown', {key: 'Enter'})
+  input.simulate('keydown', { key: 'Enter' })
   expect(renderSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({
       selectedItem: items[1],
@@ -290,15 +290,15 @@ test('Enter when there is no item at index 0 still selects the highlighted item'
 // so we have to get into the implementation details a little bit (unless we want to run these tests
 // in IE11... no thank you 🙅)
 test(`getInputProps doesn't include event handlers when disabled is passed (for IE11 support)`, () => {
-  const {getInputProps} = setupWithDownshiftController()
-  const props = getInputProps({disabled: true})
+  const { getInputProps } = setupWithDownshiftController()
+  const props = getInputProps({ disabled: true })
   const entry = Object.entries(props).find(
     ([_key, value]) => typeof value === 'function',
   )
   if (entry) {
     throw new Error(
       `getInputProps should not have any props that are callbacks. It has ${
-        entry[0]
+      entry[0]
       }.`,
     )
   }
@@ -306,34 +306,34 @@ test(`getInputProps doesn't include event handlers when disabled is passed (for 
 
 function setupDownshiftWithState() {
   const items = ['animal', 'bug', 'cat']
-  const {Component, renderSpy} = setup({items})
+  const { Component, renderSpy } = setup({ items })
   const wrapper = mount(<Component />)
   const input = wrapper.find(sel('input'))
   input.simulate('keydown')
-  input.simulate('change', {target: {value: 'a'}})
+  input.simulate('change', { target: { value: 'a' } })
   // ↓
-  input.simulate('keydown', {key: 'ArrowDown'})
+  input.simulate('keydown', { key: 'ArrowDown' })
   // ENTER to select the first one
-  input.simulate('keydown', {key: 'Enter'})
+  input.simulate('keydown', { key: 'Enter' })
   expect(input.instance().value).toBe(items[0])
   // ↓
-  input.simulate('keydown', {key: 'ArrowDown'})
-  input.simulate('change', {target: {value: 'bu'}})
+  input.simulate('keydown', { key: 'ArrowDown' })
+  input.simulate('change', { target: { value: 'bu' } })
   renderSpy.mockClear()
-  return {renderSpy, input, items, wrapper}
+  return { renderSpy, input, items, wrapper }
 }
 
-function setup({items = colors} = {}) {
+function setup({ items = colors } = {}) {
   /* eslint-disable react/jsx-closing-bracket-location */
-  const renderSpy = jest.fn(({isOpen, getInputProps, getItemProps}) => (
+  const renderSpy = jest.fn(({ isOpen, getInputProps, getItemProps }) => (
     <div>
-      <input {...getInputProps({'data-test': 'input'})} />
+      <input {...getInputProps({ 'data-test': 'input' })} />
       {isOpen && (
         <div>
           {items.map((item, index) => (
             <div
               key={item.index || index}
-              {...getItemProps({item, index: item.index || index})}
+              {...getItemProps({ item, index: item.index || index })}
             >
               {item.value ? item.value : item}
             </div>

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -689,8 +689,8 @@ class Downshift extends Component {
     // Need setTimeout, so that when the user presses Tab, the activeElement is the next focused element, not the body element
     setTimeout(() => {
       const downshiftButtonIsActive =
-        this.props.environment.document.activeElement.tagName === 'BUTTON' &&
-        this.props.environment.document.activeElement.dataset.toggle
+        this.props.environment.document.activeElement.dataset.toggle &&
+        this._rootNode.contains(this.props.environment.document.activeElement)
       if (!this.isMouseDown && !downshiftButtonIsActive) {
         this.reset({type: Downshift.stateChangeTypes.blurInput})
       }

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -1,6 +1,6 @@
 /* eslint camelcase:0 */
 
-import React, {Component} from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import preval from 'preval.macro'
 import setA11yStatus from './set-a11y-status'
@@ -83,12 +83,12 @@ class Downshift extends Component {
       }
       return String(i)
     },
-    onStateChange: () => {},
-    onInputValueChange: () => {},
-    onUserAction: () => {},
-    onChange: () => {},
-    onSelect: () => {},
-    onOuterClick: () => {},
+    onStateChange: () => { },
+    onInputValueChange: () => { },
+    onUserAction: () => { },
+    onChange: () => { },
+    onSelect: () => { },
+    onOuterClick: () => { },
     selectedItemChanged: (prevItem, item) => prevItem !== item,
     environment:
       typeof window === 'undefined' /* istanbul ignore next (ssr) */
@@ -204,7 +204,7 @@ class Downshift extends Component {
     otherStateToSet = {},
   ) => {
     otherStateToSet = pickState(otherStateToSet)
-    this.internalSetState({highlightedIndex, ...otherStateToSet})
+    this.internalSetState({ highlightedIndex, ...otherStateToSet })
   }
 
   scrollHighlightedItemIntoView = () => {
@@ -217,7 +217,7 @@ class Downshift extends Component {
   }
 
   openAndHighlightDefaultIndex = (otherStateToSet = {}) => {
-    this.setHighlightedIndex(undefined, {isOpen: true, ...otherStateToSet})
+    this.setHighlightedIndex(undefined, { isOpen: true, ...otherStateToSet })
   }
 
   highlightDefaultIndex = (otherStateToSet = {}) => {
@@ -238,7 +238,7 @@ class Downshift extends Component {
     if (itemsLastIndex < 0) {
       return
     }
-    const {highlightedIndex} = this.getState()
+    const { highlightedIndex } = this.getState()
     let baseIndex = highlightedIndex
     if (baseIndex === null) {
       baseIndex = moveAmount > 0 ? -1 : itemsLastIndex + 1
@@ -272,7 +272,7 @@ class Downshift extends Component {
         selectedItem: item,
         inputValue:
           this.isControlledProp('selectedItem') &&
-          this.props.breakingChanges.resetInputOnSelection
+            this.props.breakingChanges.resetInputOnSelection
             ? this.props.defaultInputValue
             : this.props.itemToString(item),
         ...otherStateToSet,
@@ -408,9 +408,9 @@ class Downshift extends Component {
   }
 
   getStateAndHelpers() {
-    const {highlightedIndex, inputValue, selectedItem, isOpen} = this.getState()
-    const {itemToString} = this.props
-    const {id} = this
+    const { highlightedIndex, inputValue, selectedItem, isOpen } = this.getState()
+    const { itemToString } = this.props
+    const { id } = this
     const {
       getRootProps,
       getButtonProps,
@@ -471,8 +471,8 @@ class Downshift extends Component {
   rootRef = node => (this._rootNode = node)
 
   getRootProps = (
-    {refKey = 'ref', ...rest} = {},
-    {suppressRefError = false} = {},
+    { refKey = 'ref', ...rest } = {},
+    { suppressRefError = false } = {},
   ) => {
     // this is used in the render to know whether the user has called getRootProps.
     // It uses that to know whether to apply the props automatically
@@ -515,7 +515,7 @@ class Downshift extends Component {
 
     Escape(event) {
       event.preventDefault()
-      this.reset({type: Downshift.stateChangeTypes.keyDownEscape})
+      this.reset({ type: Downshift.stateChangeTypes.keyDownEscape })
     },
   }
 
@@ -526,22 +526,22 @@ class Downshift extends Component {
 
     ' '(event) {
       event.preventDefault()
-      this.toggleMenu({type: Downshift.stateChangeTypes.keyDownSpaceButton})
+      this.toggleMenu({ type: Downshift.stateChangeTypes.keyDownSpaceButton })
     },
   }
 
-  getButtonProps = ({onClick, onKeyDown, onBlur, ...rest} = {}) => {
-    const {isOpen} = this.getState()
+  getButtonProps = ({ onClick, onKeyDown, onBlur, ...rest } = {}) => {
+    const { isOpen } = this.getState()
     const enabledEventHandlers = preval`module.exports = process.env.BUILD_REACT_NATIVE === 'true'`
       ? /* istanbul ignore next (react-native) */
-        {
-          onPress: composeEventHandlers(onClick, this.button_handleClick),
-        }
+      {
+        onPress: composeEventHandlers(onClick, this.button_handleClick),
+      }
       : {
-          onClick: composeEventHandlers(onClick, this.button_handleClick),
-          onKeyDown: composeEventHandlers(onKeyDown, this.button_handleKeyDown),
-          onBlur: composeEventHandlers(onBlur, this.button_handleBlur),
-        }
+        onClick: composeEventHandlers(onClick, this.button_handleClick),
+        onKeyDown: composeEventHandlers(onKeyDown, this.button_handleKeyDown),
+        onBlur: composeEventHandlers(onBlur, this.button_handleBlur),
+      }
     const eventHandlers = rest.disabled ? {} : enabledEventHandlers
     return {
       type: 'button',
@@ -571,13 +571,16 @@ class Downshift extends Component {
     ) {
       event.target.focus()
     }
-    this.toggleMenu({type: Downshift.stateChangeTypes.clickButton})
+    this.toggleMenu({ type: Downshift.stateChangeTypes.clickButton })
   }
 
   button_handleBlur = () => {
-    if (!this.isMouseDown) {
-      this.reset({type: Downshift.stateChangeTypes.blurButton})
-    }
+    // Need setTimeout, so that when the user presses Tab, the activeElement is the next focused element, not <body>
+    setTimeout(() => {
+      if (!this.isMouseDown && this.props.environment.document.activeElement.id !== this.inputId) {
+        this.reset({ type: Downshift.stateChangeTypes.blurButton })
+      }
+    }, 1);
   }
 
   //\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ BUTTON
@@ -593,9 +596,9 @@ class Downshift extends Component {
     ) {
       throw new Error(
         `downshift: You provided the htmlFor of "${
-          props.htmlFor
+        props.htmlFor
         }" for your label, but the id of your input is "${
-          this.inputId
+        this.inputId
         }". You must either remove the id from your input or set the htmlFor of the label equal to the input id.`,
       )
     }
@@ -610,14 +613,14 @@ class Downshift extends Component {
 
   /////////////////////////////// INPUT
 
-  getInputProps = ({onKeyDown, onBlur, onChange, onInput, ...rest} = {}) => {
+  getInputProps = ({ onKeyDown, onBlur, onChange, onInput, ...rest } = {}) => {
     this.getInputProps.called = true
     if (this.getLabelProps.called && rest.id && rest.id !== this.inputId) {
       throw new Error(
         `downshift: You provided the id of "${
-          rest.id
+        rest.id
         }" for your input, but the htmlFor of your label is "${
-          this.inputId
+        this.inputId
         }". You must either remove the id from your input or set the htmlFor of the label equal to the input id.`,
       )
     }
@@ -634,18 +637,18 @@ class Downshift extends Component {
     } else {
       onChangeKey = 'onChange'
     }
-    const {inputValue, isOpen, highlightedIndex} = this.getState()
+    const { inputValue, isOpen, highlightedIndex } = this.getState()
     const eventHandlers = rest.disabled
       ? {}
       : {
-          [onChangeKey]: composeEventHandlers(
-            onChange,
-            onInput,
-            this.input_handleChange,
-          ),
-          onKeyDown: composeEventHandlers(onKeyDown, this.input_handleKeyDown),
-          onBlur: composeEventHandlers(onBlur, this.input_handleBlur),
-        }
+        [onChangeKey]: composeEventHandlers(
+          onChange,
+          onInput,
+          this.input_handleChange,
+        ),
+        onKeyDown: composeEventHandlers(onKeyDown, this.input_handleKeyDown),
+        onBlur: composeEventHandlers(onBlur, this.input_handleBlur),
+      }
     return {
       role: 'combobox',
       'aria-autocomplete': 'list',
@@ -679,9 +682,13 @@ class Downshift extends Component {
   }
 
   input_handleBlur = () => {
-    if (!this.isMouseDown) {
-      this.reset({type: Downshift.stateChangeTypes.blurInput})
-    }
+    // Need setTimeout, so that when the user presses Tab, the activeElement is the next focused element, not <body>
+    setTimeout(() => {
+      const downshiftButtonIsActive = document.activeElement.tagName === "BUTTON" && this._rootNode.contains(this.props.environment.document.activeElement)
+      if (!this.isMouseDown && !downshiftButtonIsActive) {
+        this.reset({ type: Downshift.stateChangeTypes.blurInput })
+      }
+    }, 1);
   }
 
   //\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ INPUT
@@ -759,7 +766,7 @@ class Downshift extends Component {
   reset = (otherStateToSet = {}, cb) => {
     otherStateToSet = pickState(otherStateToSet)
     this.internalSetState(
-      ({selectedItem}) => ({
+      ({ selectedItem }) => ({
         isOpen: false,
         highlightedIndex: this.props.defaultHighlightedIndex,
         inputValue: this.props.itemToString(selectedItem),
@@ -772,11 +779,11 @@ class Downshift extends Component {
   toggleMenu = (otherStateToSet = {}, cb) => {
     otherStateToSet = pickState(otherStateToSet)
     this.internalSetState(
-      ({isOpen}) => {
-        return {isOpen: !isOpen, ...otherStateToSet}
+      ({ isOpen }) => {
+        return { isOpen: !isOpen, ...otherStateToSet }
       },
       () => {
-        const {isOpen} = this.getState()
+        const { isOpen } = this.getState()
         if (isOpen) {
           this.highlightDefaultIndex()
         }
@@ -786,11 +793,11 @@ class Downshift extends Component {
   }
 
   openMenu = cb => {
-    this.internalSetState({isOpen: true}, cbToCb(cb))
+    this.internalSetState({ isOpen: true }, cbToCb(cb))
   }
 
   closeMenu = cb => {
-    this.internalSetState({isOpen: false}, cbToCb(cb))
+    this.internalSetState({ isOpen: false }, cbToCb(cb))
   }
 
   updateStatus = debounce(() => {
@@ -833,7 +840,7 @@ class Downshift extends Component {
         this.isMouseDown = true
       }
       const onMouseUp = event => {
-        const {document} = this.props.environment
+        const { document } = this.props.environment
         this.isMouseDown = false
         if (
           (event.target === this._rootNode ||
@@ -841,7 +848,7 @@ class Downshift extends Component {
           this.getState().isOpen &&
           (!this.inputId || document.activeElement.id !== this.inputId)
         ) {
-          this.reset({type: Downshift.stateChangeTypes.mouseUp}, () =>
+          this.reset({ type: Downshift.stateChangeTypes.mouseUp }, () =>
             this.props.onOuterClick(this.getStateAndHelpers()),
           )
         }
@@ -935,7 +942,7 @@ class Downshift extends Component {
 
 export default Downshift
 
-function validateGetRootPropsCalledCorrectly(element, {refKey}) {
+function validateGetRootPropsCalledCorrectly(element, { refKey }) {
   const refKeySpecified = refKey !== 'ref'
   const isComposite = !isDOMElement(element)
   if (isComposite && !refKeySpecified) {

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -583,7 +583,7 @@ class Downshift extends Component {
       ) {
         this.reset({type: Downshift.stateChangeTypes.blurButton})
       }
-    }, 1)
+    })
   }
 
   //\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ BUTTON
@@ -693,7 +693,7 @@ class Downshift extends Component {
       if (!this.isMouseDown && !downshiftButtonIsActive) {
         this.reset({type: Downshift.stateChangeTypes.blurInput})
       }
-    }, 1)
+    })
   }
 
   //\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ INPUT

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -1,6 +1,6 @@
 /* eslint camelcase:0 */
 
-import React, { Component } from 'react'
+import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import preval from 'preval.macro'
 import setA11yStatus from './set-a11y-status'
@@ -83,12 +83,12 @@ class Downshift extends Component {
       }
       return String(i)
     },
-    onStateChange: () => { },
-    onInputValueChange: () => { },
-    onUserAction: () => { },
-    onChange: () => { },
-    onSelect: () => { },
-    onOuterClick: () => { },
+    onStateChange: () => {},
+    onInputValueChange: () => {},
+    onUserAction: () => {},
+    onChange: () => {},
+    onSelect: () => {},
+    onOuterClick: () => {},
     selectedItemChanged: (prevItem, item) => prevItem !== item,
     environment:
       typeof window === 'undefined' /* istanbul ignore next (ssr) */
@@ -204,7 +204,7 @@ class Downshift extends Component {
     otherStateToSet = {},
   ) => {
     otherStateToSet = pickState(otherStateToSet)
-    this.internalSetState({ highlightedIndex, ...otherStateToSet })
+    this.internalSetState({highlightedIndex, ...otherStateToSet})
   }
 
   scrollHighlightedItemIntoView = () => {
@@ -217,7 +217,7 @@ class Downshift extends Component {
   }
 
   openAndHighlightDefaultIndex = (otherStateToSet = {}) => {
-    this.setHighlightedIndex(undefined, { isOpen: true, ...otherStateToSet })
+    this.setHighlightedIndex(undefined, {isOpen: true, ...otherStateToSet})
   }
 
   highlightDefaultIndex = (otherStateToSet = {}) => {
@@ -238,7 +238,7 @@ class Downshift extends Component {
     if (itemsLastIndex < 0) {
       return
     }
-    const { highlightedIndex } = this.getState()
+    const {highlightedIndex} = this.getState()
     let baseIndex = highlightedIndex
     if (baseIndex === null) {
       baseIndex = moveAmount > 0 ? -1 : itemsLastIndex + 1
@@ -272,7 +272,7 @@ class Downshift extends Component {
         selectedItem: item,
         inputValue:
           this.isControlledProp('selectedItem') &&
-            this.props.breakingChanges.resetInputOnSelection
+          this.props.breakingChanges.resetInputOnSelection
             ? this.props.defaultInputValue
             : this.props.itemToString(item),
         ...otherStateToSet,
@@ -408,9 +408,9 @@ class Downshift extends Component {
   }
 
   getStateAndHelpers() {
-    const { highlightedIndex, inputValue, selectedItem, isOpen } = this.getState()
-    const { itemToString } = this.props
-    const { id } = this
+    const {highlightedIndex, inputValue, selectedItem, isOpen} = this.getState()
+    const {itemToString} = this.props
+    const {id} = this
     const {
       getRootProps,
       getButtonProps,
@@ -471,8 +471,8 @@ class Downshift extends Component {
   rootRef = node => (this._rootNode = node)
 
   getRootProps = (
-    { refKey = 'ref', ...rest } = {},
-    { suppressRefError = false } = {},
+    {refKey = 'ref', ...rest} = {},
+    {suppressRefError = false} = {},
   ) => {
     // this is used in the render to know whether the user has called getRootProps.
     // It uses that to know whether to apply the props automatically
@@ -515,7 +515,7 @@ class Downshift extends Component {
 
     Escape(event) {
       event.preventDefault()
-      this.reset({ type: Downshift.stateChangeTypes.keyDownEscape })
+      this.reset({type: Downshift.stateChangeTypes.keyDownEscape})
     },
   }
 
@@ -526,22 +526,22 @@ class Downshift extends Component {
 
     ' '(event) {
       event.preventDefault()
-      this.toggleMenu({ type: Downshift.stateChangeTypes.keyDownSpaceButton })
+      this.toggleMenu({type: Downshift.stateChangeTypes.keyDownSpaceButton})
     },
   }
 
-  getButtonProps = ({ onClick, onKeyDown, onBlur, ...rest } = {}) => {
-    const { isOpen } = this.getState()
+  getButtonProps = ({onClick, onKeyDown, onBlur, ...rest} = {}) => {
+    const {isOpen} = this.getState()
     const enabledEventHandlers = preval`module.exports = process.env.BUILD_REACT_NATIVE === 'true'`
       ? /* istanbul ignore next (react-native) */
-      {
-        onPress: composeEventHandlers(onClick, this.button_handleClick),
-      }
+        {
+          onPress: composeEventHandlers(onClick, this.button_handleClick),
+        }
       : {
-        onClick: composeEventHandlers(onClick, this.button_handleClick),
-        onKeyDown: composeEventHandlers(onKeyDown, this.button_handleKeyDown),
-        onBlur: composeEventHandlers(onBlur, this.button_handleBlur),
-      }
+          onClick: composeEventHandlers(onClick, this.button_handleClick),
+          onKeyDown: composeEventHandlers(onKeyDown, this.button_handleKeyDown),
+          onBlur: composeEventHandlers(onBlur, this.button_handleBlur),
+        }
     const eventHandlers = rest.disabled ? {} : enabledEventHandlers
     return {
       type: 'button',
@@ -571,16 +571,19 @@ class Downshift extends Component {
     ) {
       event.target.focus()
     }
-    this.toggleMenu({ type: Downshift.stateChangeTypes.clickButton })
+    this.toggleMenu({type: Downshift.stateChangeTypes.clickButton})
   }
 
   button_handleBlur = () => {
-    // Need setTimeout, so that when the user presses Tab, the activeElement is the next focused element, not <body>
+    // Need setTimeout, so that when the user presses Tab, the activeElement is the next focused element, not body element
     setTimeout(() => {
-      if (!this.isMouseDown && this.props.environment.document.activeElement.id !== this.inputId) {
-        this.reset({ type: Downshift.stateChangeTypes.blurButton })
+      if (
+        !this.isMouseDown &&
+        this.props.environment.document.activeElement.id !== this.inputId
+      ) {
+        this.reset({type: Downshift.stateChangeTypes.blurButton})
       }
-    }, 1);
+    }, 1)
   }
 
   //\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ BUTTON
@@ -596,9 +599,9 @@ class Downshift extends Component {
     ) {
       throw new Error(
         `downshift: You provided the htmlFor of "${
-        props.htmlFor
+          props.htmlFor
         }" for your label, but the id of your input is "${
-        this.inputId
+          this.inputId
         }". You must either remove the id from your input or set the htmlFor of the label equal to the input id.`,
       )
     }
@@ -613,14 +616,14 @@ class Downshift extends Component {
 
   /////////////////////////////// INPUT
 
-  getInputProps = ({ onKeyDown, onBlur, onChange, onInput, ...rest } = {}) => {
+  getInputProps = ({onKeyDown, onBlur, onChange, onInput, ...rest} = {}) => {
     this.getInputProps.called = true
     if (this.getLabelProps.called && rest.id && rest.id !== this.inputId) {
       throw new Error(
         `downshift: You provided the id of "${
-        rest.id
+          rest.id
         }" for your input, but the htmlFor of your label is "${
-        this.inputId
+          this.inputId
         }". You must either remove the id from your input or set the htmlFor of the label equal to the input id.`,
       )
     }
@@ -637,18 +640,18 @@ class Downshift extends Component {
     } else {
       onChangeKey = 'onChange'
     }
-    const { inputValue, isOpen, highlightedIndex } = this.getState()
+    const {inputValue, isOpen, highlightedIndex} = this.getState()
     const eventHandlers = rest.disabled
       ? {}
       : {
-        [onChangeKey]: composeEventHandlers(
-          onChange,
-          onInput,
-          this.input_handleChange,
-        ),
-        onKeyDown: composeEventHandlers(onKeyDown, this.input_handleKeyDown),
-        onBlur: composeEventHandlers(onBlur, this.input_handleBlur),
-      }
+          [onChangeKey]: composeEventHandlers(
+            onChange,
+            onInput,
+            this.input_handleChange,
+          ),
+          onKeyDown: composeEventHandlers(onKeyDown, this.input_handleKeyDown),
+          onBlur: composeEventHandlers(onBlur, this.input_handleBlur),
+        }
     return {
       role: 'combobox',
       'aria-autocomplete': 'list',
@@ -682,13 +685,15 @@ class Downshift extends Component {
   }
 
   input_handleBlur = () => {
-    // Need setTimeout, so that when the user presses Tab, the activeElement is the next focused element, not <body>
+    // Need setTimeout, so that when the user presses Tab, the activeElement is the next focused element, not the body element
     setTimeout(() => {
-      const downshiftButtonIsActive = document.activeElement.tagName === "BUTTON" && this._rootNode.contains(this.props.environment.document.activeElement)
+      const downshiftButtonIsActive =
+        this.props.environment.document.activeElement.tagName === 'BUTTON' &&
+        this._rootNode.contains(this.props.environment.document.activeElement)
       if (!this.isMouseDown && !downshiftButtonIsActive) {
-        this.reset({ type: Downshift.stateChangeTypes.blurInput })
+        this.reset({type: Downshift.stateChangeTypes.blurInput})
       }
-    }, 1);
+    }, 1)
   }
 
   //\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ INPUT
@@ -766,7 +771,7 @@ class Downshift extends Component {
   reset = (otherStateToSet = {}, cb) => {
     otherStateToSet = pickState(otherStateToSet)
     this.internalSetState(
-      ({ selectedItem }) => ({
+      ({selectedItem}) => ({
         isOpen: false,
         highlightedIndex: this.props.defaultHighlightedIndex,
         inputValue: this.props.itemToString(selectedItem),
@@ -779,11 +784,11 @@ class Downshift extends Component {
   toggleMenu = (otherStateToSet = {}, cb) => {
     otherStateToSet = pickState(otherStateToSet)
     this.internalSetState(
-      ({ isOpen }) => {
-        return { isOpen: !isOpen, ...otherStateToSet }
+      ({isOpen}) => {
+        return {isOpen: !isOpen, ...otherStateToSet}
       },
       () => {
-        const { isOpen } = this.getState()
+        const {isOpen} = this.getState()
         if (isOpen) {
           this.highlightDefaultIndex()
         }
@@ -793,11 +798,11 @@ class Downshift extends Component {
   }
 
   openMenu = cb => {
-    this.internalSetState({ isOpen: true }, cbToCb(cb))
+    this.internalSetState({isOpen: true}, cbToCb(cb))
   }
 
   closeMenu = cb => {
-    this.internalSetState({ isOpen: false }, cbToCb(cb))
+    this.internalSetState({isOpen: false}, cbToCb(cb))
   }
 
   updateStatus = debounce(() => {
@@ -840,7 +845,7 @@ class Downshift extends Component {
         this.isMouseDown = true
       }
       const onMouseUp = event => {
-        const { document } = this.props.environment
+        const {document} = this.props.environment
         this.isMouseDown = false
         if (
           (event.target === this._rootNode ||
@@ -848,7 +853,7 @@ class Downshift extends Component {
           this.getState().isOpen &&
           (!this.inputId || document.activeElement.id !== this.inputId)
         ) {
-          this.reset({ type: Downshift.stateChangeTypes.mouseUp }, () =>
+          this.reset({type: Downshift.stateChangeTypes.mouseUp}, () =>
             this.props.onOuterClick(this.getStateAndHelpers()),
           )
         }
@@ -942,7 +947,7 @@ class Downshift extends Component {
 
 export default Downshift
 
-function validateGetRootPropsCalledCorrectly(element, { refKey }) {
+function validateGetRootPropsCalledCorrectly(element, {refKey}) {
   const refKeySpecified = refKey !== 'ref'
   const isComposite = !isDOMElement(element)
   if (isComposite && !refKeySpecified) {

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -549,6 +549,7 @@ class Downshift extends Component {
       'aria-label': isOpen ? 'close menu' : 'open menu',
       'aria-expanded': isOpen,
       'aria-haspopup': true,
+      'data-toggle': true,
       ...eventHandlers,
       ...rest,
     }
@@ -689,7 +690,7 @@ class Downshift extends Component {
     setTimeout(() => {
       const downshiftButtonIsActive =
         this.props.environment.document.activeElement.tagName === 'BUTTON' &&
-        this._rootNode.contains(this.props.environment.document.activeElement)
+        this.props.environment.document.activeElement.dataset.toggle
       if (!this.isMouseDown && !downshiftButtonIsActive) {
         this.reset({type: Downshift.stateChangeTypes.blurInput})
       }

--- a/stories/examples/semantic-ui.js
+++ b/stories/examples/semantic-ui.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import matchSorter from 'match-sorter'
-import glamorous, {Div} from 'glamorous'
+import glamorous, { Div } from 'glamorous'
 import items from '../countries'
 
 import Downshift from '../../src'
@@ -44,7 +44,7 @@ const Item = glamorous.div(
     whiteSpace: 'normal',
     wordWrap: 'normal',
   },
-  ({isActive, isSelected}) => {
+  ({ isActive, isSelected }) => {
     const styles = []
     if (isActive) {
       styles.push({
@@ -88,12 +88,12 @@ const Input = glamorous.input(
       boxShadow: '0 2px 3px 0 rgba(34,36,38,.15)',
     },
   },
-  ({isOpen}) =>
+  ({ isOpen }) =>
     isOpen
       ? {
-          borderBottomLeftRadius: '0',
-          borderBottomRightRadius: '0',
-        }
+        borderBottomLeftRadius: '0',
+        borderBottomRightRadius: '0',
+      }
       : null,
 )
 
@@ -146,53 +146,58 @@ function SemanticUIAutocomplete() {
         getInputProps,
         getItemProps,
       }) => (
-        <Div {...getRootProps({refKey: 'innerRef'})}>
-          <Div position="relative" css={{paddingRight: '1.75em'}}>
-            <Input
-              {...getInputProps({
-                isOpen,
-                placeholder: 'Enter some info',
-              })}
-            />
-            {selectedItem ? (
-              <ControlButton
-                css={{paddingTop: 4}}
-                onClick={clearSelection}
-                aria-label="clear selection"
-              >
-                <XIcon />
-              </ControlButton>
-            ) : (
-              <ControlButton {...getButtonProps()}>
-                <ArrowIcon isOpen={isOpen} />
-              </ControlButton>
+          <Div {...getRootProps({ refKey: 'innerRef' })}>
+            <Div position="relative" css={{ paddingRight: '1.75em' }}>
+              <Input
+                {...getInputProps({
+                  isOpen,
+                  placeholder: 'Enter some info',
+                  'data-test': 'semantic-ui-input',
+                })}
+              />
+              {selectedItem ? (
+                <ControlButton
+                  css={{ paddingTop: 4 }}
+                  onClick={clearSelection}
+                  aria-label="clear selection"
+                  data-test='semantic-ui-clear-button'
+                >
+                  <XIcon />
+                </ControlButton>
+              ) : (
+                  <ControlButton {...getButtonProps({
+                    'data-test': 'semantic-ui-toggle-button',
+                  })}>
+                    <ArrowIcon isOpen={isOpen} />
+                  </ControlButton>
+                )}
+            </Div>
+            {isOpen && (
+              <Menu>
+                {(inputValue ? advancedFilter(items, inputValue) : items).map(
+                  (item, index) => (
+                    <Item
+                      key={item.code}
+                      {...getItemProps({
+                        item,
+                        'data-test': `downshift-item-${index}`,
+                        isActive: highlightedIndex === index,
+                        isSelected: selectedItem === item,
+                      })}
+                    >
+                      {item.name}
+                    </Item>
+                  ),
+                )}
+              </Menu>
             )}
-          </Div>
-          {isOpen && (
-            <Menu>
-              {(inputValue ? advancedFilter(items, inputValue) : items).map(
-                (item, index) => (
-                  <Item
-                    key={item.code}
-                    {...getItemProps({
-                      item,
-                      isActive: highlightedIndex === index,
-                      isSelected: selectedItem === item,
-                    })}
-                  >
-                    {item.name}
-                  </Item>
-                ),
-              )}
-            </Menu>
-          )}
-        </Div>
-      )}
+          </ Div>
+        )}
     />
   )
 }
 
-function ArrowIcon({isOpen}) {
+function ArrowIcon({ isOpen }) {
   return (
     <svg
       viewBox="0 0 20 20"

--- a/stories/examples/semantic-ui.js
+++ b/stories/examples/semantic-ui.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import matchSorter from 'match-sorter'
-import glamorous, { Div } from 'glamorous'
+import glamorous, {Div} from 'glamorous'
 import items from '../countries'
 
 import Downshift from '../../src'
@@ -44,7 +44,7 @@ const Item = glamorous.div(
     whiteSpace: 'normal',
     wordWrap: 'normal',
   },
-  ({ isActive, isSelected }) => {
+  ({isActive, isSelected}) => {
     const styles = []
     if (isActive) {
       styles.push({
@@ -88,12 +88,12 @@ const Input = glamorous.input(
       boxShadow: '0 2px 3px 0 rgba(34,36,38,.15)',
     },
   },
-  ({ isOpen }) =>
+  ({isOpen}) =>
     isOpen
       ? {
-        borderBottomLeftRadius: '0',
-        borderBottomRightRadius: '0',
-      }
+          borderBottomLeftRadius: '0',
+          borderBottomRightRadius: '0',
+        }
       : null,
 )
 
@@ -146,58 +146,60 @@ function SemanticUIAutocomplete() {
         getInputProps,
         getItemProps,
       }) => (
-          <Div {...getRootProps({ refKey: 'innerRef' })}>
-            <Div position="relative" css={{ paddingRight: '1.75em' }}>
-              <Input
-                {...getInputProps({
-                  isOpen,
-                  placeholder: 'Enter some info',
-                  'data-test': 'semantic-ui-input',
+        <Div {...getRootProps({refKey: 'innerRef'})}>
+          <Div position="relative" css={{paddingRight: '1.75em'}}>
+            <Input
+              {...getInputProps({
+                isOpen,
+                placeholder: 'Enter some info',
+                'data-test': 'semantic-ui-input',
+              })}
+            />
+            {selectedItem ? (
+              <ControlButton
+                css={{paddingTop: 4}}
+                onClick={clearSelection}
+                aria-label="clear selection"
+                data-test="semantic-ui-clear-button"
+              >
+                <XIcon />
+              </ControlButton>
+            ) : (
+              <ControlButton
+                {...getButtonProps({
+                  'data-test': 'semantic-ui-toggle-button',
                 })}
-              />
-              {selectedItem ? (
-                <ControlButton
-                  css={{ paddingTop: 4 }}
-                  onClick={clearSelection}
-                  aria-label="clear selection"
-                  data-test='semantic-ui-clear-button'
-                >
-                  <XIcon />
-                </ControlButton>
-              ) : (
-                  <ControlButton {...getButtonProps({
-                    'data-test': 'semantic-ui-toggle-button',
-                  })}>
-                    <ArrowIcon isOpen={isOpen} />
-                  </ControlButton>
-                )}
-            </Div>
-            {isOpen && (
-              <Menu>
-                {(inputValue ? advancedFilter(items, inputValue) : items).map(
-                  (item, index) => (
-                    <Item
-                      key={item.code}
-                      {...getItemProps({
-                        item,
-                        'data-test': `downshift-item-${index}`,
-                        isActive: highlightedIndex === index,
-                        isSelected: selectedItem === item,
-                      })}
-                    >
-                      {item.name}
-                    </Item>
-                  ),
-                )}
-              </Menu>
+              >
+                <ArrowIcon isOpen={isOpen} />
+              </ControlButton>
             )}
-          </ Div>
-        )}
+          </Div>
+          {isOpen && (
+            <Menu>
+              {(inputValue ? advancedFilter(items, inputValue) : items).map(
+                (item, index) => (
+                  <Item
+                    key={item.code}
+                    {...getItemProps({
+                      item,
+                      'data-test': `downshift-item-${index}`,
+                      isActive: highlightedIndex === index,
+                      isSelected: selectedItem === item,
+                    })}
+                  >
+                    {item.name}
+                  </Item>
+                ),
+              )}
+            </Menu>
+          )}
+        </Div>
+      )}
     />
   )
 }
 
-function ArrowIcon({ isOpen }) {
+function ArrowIcon({isOpen}) {
   return (
     <svg
       viewBox="0 0 20 20"


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Allow user to tab from input to button without resetting, and allow user to shift+tab from button to input without resetting. See https://github.com/paypal/downshift/issues/364 for more details.

<!-- Why are these changes necessary? -->

**Why**: If user wanted to only use keyboard to navigate between input and toggle button, the current usage would be a nuisance

<!-- How were these changes implemented? -->

**How**: added checks in `input_handleBlur` and `button_handleBlur` to make sure that the new `activeElement` is not a downshift button or downshift input, respectively. Added cypress tests which pass, but I have some work to do regarding keeping and obtaining 100% test coverage

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation - N/A
* [ ] Tests - kinda
* [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

Had to add setTimeout in order to prevent the activeElement from being <body>. I looked around and couldn't find any other way to do it. See this link for more info: https://stackoverflow.com/questions/121499/when-a-blur-event-occurs-how-can-i-find-out-which-element-focus-went-to

It all works, and the cypress tests pass.

Having some issues with the jest tests:

```
● on input blur resets the state

expect(jest.fn()).toHaveBeenLastCalledWith(expected)

Expected mock function to have been last called with:
  [ObjectContaining {"inputValue": "animal", "isOpen": false, "selectedItem": "animal"}]
But it was not called.

      170 |   const {input, renderSpy, items} = setupDownshiftWithState()
      171 |   input.simulate('blur')
    > 172 |   expect(renderSpy).toHaveBeenLastCalledWith(
      173 |     expect.objectContaining({
      174 |       isOpen: false,
      175 |       inputValue: items[0],
```
Also, I need to add jest tests for the `setTimeout` fns.

I'll look into my testing issues later, but if anyone has suggestions, let me know!