### PR TITLE
Add style to TS types

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -60,6 +60,7 @@ export interface DownshiftProps {
   render?: ChildrenFunction
   children?: ChildrenFunction
   id?: string
+  style?: React.CSSProperties
   environment?: Environment
   onOuterClick?: () => void
   onUserAction?: (


### PR DESCRIPTION
Saw this was passed directly to `<Downshift>` in the react-popper example.

Reference: https://github.com/paypal/downshift/blob/master/stories/examples/react-popper.js#L49

