### PR TITLE
fix: add null-check for `this._rootNode`

### DIFF
--- a/src/downshift.js
+++ b/src/downshift.js
@@ -211,8 +211,7 @@ class Downshift extends Component {
     /* istanbul ignore else (react-native) */
     if (preval`module.exports = process.env.BUILD_REACT_NATIVE !== 'true'`) {
       const node = this.getItemNodeFromIndex(this.getState().highlightedIndex)
-      const rootNode = this._rootNode
-      scrollIntoView(node, rootNode)
+      scrollIntoView(node, this._rootNode)
     }
   }
 
@@ -690,7 +689,10 @@ class Downshift extends Component {
     setTimeout(() => {
       const downshiftButtonIsActive =
         this.props.environment.document.activeElement.dataset.toggle &&
-        this._rootNode.contains(this.props.environment.document.activeElement)
+        (this._rootNode &&
+          this._rootNode.contains(
+            this.props.environment.document.activeElement,
+          ))
       if (!this.isMouseDown && !downshiftButtonIsActive) {
         this.reset({type: Downshift.stateChangeTypes.blurInput})
       }
@@ -848,11 +850,16 @@ class Downshift extends Component {
       const onMouseUp = event => {
         const {document} = this.props.environment
         this.isMouseDown = false
+        const targetIsRoot = event.target === this._rootNode
+        const rootContainsTarget =
+          this._rootNode && this._rootNode.contains(event.target)
+        const targetInDownshift = targetIsRoot || rootContainsTarget
+        const targetIsDownshiftInput =
+          this.inputId && document.activeElement.id === this.inputId
         if (
-          (event.target === this._rootNode ||
-            !this._rootNode.contains(event.target)) &&
+          !targetInDownshift &&
           this.getState().isOpen &&
-          (!this.inputId || document.activeElement.id !== this.inputId)
+          !targetIsDownshiftInput
         ) {
           this.reset({type: Downshift.stateChangeTypes.mouseUp}, () =>
             this.props.onOuterClick(this.getStateAndHelpers()),


### PR DESCRIPTION
**What**: Add a null check for `this._rootNode`

Also refactor so we can read the code

<!-- Why are these changes necessary? -->

**Why**: Closes #366

<!-- How were these changes implemented? -->

**How**:
- Give variable names to things, and use `this._rootNode &&`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [x] Tests
* [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table N/a
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
