### PR TITLE
fix(mouseup): do not reset when active element is in downshift

### DIFF
--- a/src/downshift.js
+++ b/src/downshift.js
@@ -14,6 +14,7 @@ import {
   getA11yStatusMessage,
   unwrapArray,
   isDOMElement,
+  isOrContainsNode,
   getElementProps,
   noop,
   requiredProp,
@@ -850,16 +851,15 @@ class Downshift extends Component {
       const onMouseUp = event => {
         const {document} = this.props.environment
         this.isMouseDown = false
-        const targetIsRoot = event.target === this._rootNode
-        const rootContainsTarget =
-          this._rootNode && this._rootNode.contains(event.target)
-        const targetInDownshift = targetIsRoot || rootContainsTarget
-        const targetIsDownshiftInput =
-          this.inputId && document.activeElement.id === this.inputId
+        const targetInDownshift =
+          this._rootNode && isOrContainsNode(this._rootNode, event.target)
+        const activeElementInDownshift =
+          this._rootNode &&
+          isOrContainsNode(this._rootNode, document.activeElement)
         if (
           !targetInDownshift &&
-          this.getState().isOpen &&
-          !targetIsDownshiftInput
+          !activeElementInDownshift &&
+          this.getState().isOpen
         ) {
           this.reset({type: Downshift.stateChangeTypes.mouseUp}, () =>
             this.props.onOuterClick(this.getStateAndHelpers()),

--- a/src/utils.js
+++ b/src/utils.js
@@ -108,6 +108,15 @@ function scrollIntoView(node, rootNode) {
 }
 
 /**
+ * @param {HTMLElement} parent the parent node
+ * @param {HTMLElement} child the child node
+ * @return {Boolean} whether the parent is the child or the child is in the parent
+ */
+function isOrContainsNode(parent, child) {
+  return parent === child || parent.contains(child)
+}
+
+/**
  * Simple debounce implementation. Will call the given
  * function once after the time given has passed since
  * it was last called.
@@ -287,6 +296,7 @@ export {
   unwrapArray,
   isDOMElement,
   getElementProps,
+  isOrContainsNode,
   noop,
   requiredProp,
   setIdCounter,


### PR DESCRIPTION
**What**: do not reset when active element is in downshift

**Why**: Closes #356

<!-- How were these changes implemented? -->

**How**:
- Add util for checking whether a node is or contains something
- Use that util for both the event.target and the document.activeElement
- Use that instead of the input

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [x] Tests
* [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table N/A
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
