### PR TITLE
Fix keyboard events for IE and Edge in preact

### DIFF
--- a/src/downshift.js
+++ b/src/downshift.js
@@ -668,7 +668,9 @@ class Downshift extends Component {
   }
 
   input_handleKeyDown = event => {
-    var key = event.key
+    let key = event.key
+    // handle issue with IE/Edge not including "Arrow" as a prefix for the key
+    /* istanbul ignore next (ie) */
     if ((event.keyCode >= 37 && event.keyCode <= 40) && !key.startsWith('Arrow')) {
       key = 'Arrow' + event.key
     }

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -668,8 +668,13 @@ class Downshift extends Component {
   }
 
   input_handleKeyDown = event => {
-    if (event.key && this.keyDownHandlers[event.key]) {
-      this.keyDownHandlers[event.key].call(this, event)
+    var key = event.key
+    if ((event.keyCode >= 37 && event.keyCode <= 40) && !key.startsWith('Arrow')) {
+      key = 'Arrow' + event.key
+    }
+
+    if (key && this.keyDownHandlers[key]) {
+      this.keyDownHandlers[key].call(this, event)
     }
   }
 

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -672,7 +672,7 @@ class Downshift extends Component {
     // handle issue with IE/Edge not including "Arrow" as a prefix for the key
     /* istanbul ignore next (ie) */
     if ((event.keyCode >= 37 && event.keyCode <= 40) && !key.startsWith('Arrow')) {
-      key = 'Arrow' + event.key
+      key = `Arrow${event.key}`
     }
 
     if (key && this.keyDownHandlers[key]) {


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: IE and certain versions of Edge followed an earlier draft of the DOM spec, and do not include 'Arrow' in their `event.key` events when arrow keys are used (i.e. 'Down' instead of 'ArrowDown', etc). This has been [patched in Edge](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8860571/), but won't be backported to IE. 
<!-- Why are these changes necessary? -->

**Why**: Preact does not use syntetic events like react does, and as a result arrow keys do not currently work with preact in those browsers.


<!-- How were these changes implemented? -->

**How**: check if a keycode is within 37-40 (the range of keyboard arrow keys), and if it does not start with `Arrow`, prepend it to the value.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation NA
* [ ] Tests NA
* [ x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table NA
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
