### PR TITLE
Fix: replace String method not supported in IE11

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -292,7 +292,7 @@ function pickState(state = {}) {
 function normalizeArrowKey(event) {
   const { key, keyCode } = event
   /* istanbul ignore next (ie) */
-  if (keyCode >= 37 && keyCode <= 40 && !key.startsWith('Arrow')) {
+  if (keyCode >= 37 && keyCode <= 40 && key.indexOf('Arrow') !== 0) {
     return `Arrow${key}`
   }
   return key


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Replaced a string method that works in Edge but not IE11.

<!-- Why are these changes necessary? -->

**Why**: IE 11 does not support `String.prototype.startsWith`. This method was previously used in #414 and #412 .

<!-- How were these changes implemented? -->

**How**: Replaced the String `startsWith` method with `indexOf`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [ ] Tests
* [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
