### PR TITLE
fix(native): Support both onChange and onChangeText props

### DIFF
--- a/other/react-native/__tests__/__snapshots__/render-tests.js.snap
+++ b/other/react-native/__tests__/__snapshots__/render-tests.js.snap
@@ -17,6 +17,7 @@ exports[`renders with React Native components 1`] = `
     autoComplete="off"
     id="downshift-0-input"
     onBlur={[Function]}
+    onChange={[Function]}
     onChangeText={[Function]}
     onKeyDown={[Function]}
     value=""

--- a/other/react-native/__tests__/onChange-tests.js
+++ b/other/react-native/__tests__/onChange-tests.js
@@ -1,0 +1,76 @@
+import {Text, TextInput, View} from 'react-native'
+import React from 'react'
+
+// Note: test renderer must be required after react-native.
+import TestRenderer from 'react-test-renderer'
+
+import Downshift from '../../../dist/downshift.native.cjs'
+
+const RootView = ({innerRef, ...rest}) => <View ref={innerRef} {...rest} />
+
+test('calls onChange when TextInput changes values', () => {
+  const onChange = jest.fn()
+  const Input = jest.fn(props => <TextInput {...props} />)
+
+  const element = (
+    <Downshift>
+      {({getRootProps, getInputProps, getItemProps}) => (
+        <RootView {...getRootProps({refKey: 'innerRef'})}>
+          <Input {...getInputProps({onChange})} />
+          <View>
+            <Text {...getItemProps({item: 'foo', index: 0})}>foo</Text>
+            <Text {...getItemProps({item: 'bar', index: 1})}>bar</Text>
+          </View>
+        </RootView>
+      )}
+    </Downshift>
+  )
+  TestRenderer.create(element)
+
+  const [[firstArg]] = Input.mock.calls
+  expect(firstArg).toMatchObject({
+    onChange: expect.any(Function),
+  })
+  const fakeEvent = {nativeEvent: {text: 'foobar'}}
+  firstArg.onChange(fakeEvent)
+
+  expect(onChange).toHaveBeenCalledTimes(1)
+  expect(onChange).toHaveBeenCalledWith(fakeEvent)
+})
+
+test('calls onChangeText when TextInput changes values', () => {
+  const onChangeText = jest.fn()
+  const Input = jest.fn(props => <TextInput {...props} />)
+
+  const element = (
+    <Downshift>
+      {({getRootProps, getInputProps, getItemProps}) => (
+        <RootView {...getRootProps({refKey: 'innerRef'})}>
+          <Input {...getInputProps({onChangeText})} />
+          <View>
+            <Text {...getItemProps({item: 'foo', index: 0})}>foo</Text>
+            <Text {...getItemProps({item: 'bar', index: 1})}>bar</Text>
+          </View>
+        </RootView>
+      )}
+    </Downshift>
+  )
+  TestRenderer.create(element)
+
+  const [[firstArg]] = Input.mock.calls
+  expect(firstArg).toMatchObject({
+    onChangeText: expect.any(Function),
+  })
+  const fakeEvent = 'foobar'
+  firstArg.onChangeText(fakeEvent)
+
+  expect(onChangeText).toHaveBeenCalledTimes(1)
+  expect(onChangeText).toHaveBeenCalledWith(fakeEvent)
+})
+
+/*
+ eslint
+  react/prop-types: 0,
+  import/extensions: 0,
+  import/no-unresolved: 0
+ */

--- a/other/react-native/__tests__/render-tests.js
+++ b/other/react-native/__tests__/render-tests.js
@@ -1,5 +1,3 @@
-/* eslint-disable react/prop-types */
-// eslint-disable-next-line import/no-unassigned-import
 import {Text, TextInput, View} from 'react-native'
 import React from 'react'
 
@@ -47,37 +45,6 @@ test('can use children instead of render prop', () => {
   const element = <Downshift>{childrenSpy}</Downshift>
   TestRenderer.create(element)
   expect(childrenSpy).toHaveBeenCalledTimes(1)
-})
-
-test('calls onChange when TextInput changes values', () => {
-  const onChange = jest.fn()
-  const Input = jest.fn(props => <TextInput {...props} />)
-
-  const RootView = ({innerRef, ...rest}) => <View ref={innerRef} {...rest} />
-  const childrenSpy = jest.fn(({getRootProps, getInputProps, getItemProps}) => (
-    <RootView {...getRootProps({refKey: 'innerRef'})}>
-      <Input {...getInputProps({onChange})} />
-      <View>
-        <Text {...getItemProps({item: 'foo', index: 0})}>foo</Text>
-        <Text {...getItemProps({item: 'bar', index: 1})}>bar</Text>
-      </View>
-    </RootView>
-  ))
-  const element = <Downshift>{childrenSpy}</Downshift>
-  TestRenderer.create(element)
-  expect(childrenSpy).toHaveBeenCalledTimes(1)
-
-  const [[firstArg]] = Input.mock.calls
-  expect(firstArg).toMatchObject({
-    // TODO: We shouldn't need to know about the internals of how we're affecting the TextInput and what props we're supplying.
-    // See https://github.com/paypal/downshift/issues/361
-    onChangeText: expect.any(Function),
-  })
-  const fakeEvent = 'foobar'
-  firstArg.onChangeText(fakeEvent)
-
-  expect(onChange).toHaveBeenCalledTimes(1)
-  expect(onChange).toHaveBeenCalledWith(fakeEvent)
 })
 
 /*


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

This supports both props that <TextInput /> accepts for supporting text
input changed events.

Additionally, this moves onChange related tests to their own module.

<!-- Why are these changes necessary? -->

**Why**:

Fixes #361 

<!-- How were these changes implemented? -->

**How**:

Adds additional argument to `getInputProps` that is only used on React Native builds. This argument is then used to provide an additional event handler.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
