### PR TITLE
Publish flow typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   "files": [
     "dist",
     "typings",
-    "preact"
+    "preact",
+    "flow-typed"
   ],
   "keywords": [
     "enhanced input",


### PR DESCRIPTION
Currently the `flow-typed` dir is not published.