### PR TITLE
fix(types): Restored resetIdCounter TS type

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -199,3 +199,4 @@ export type DownshiftInterface<Item> = React.ComponentClass<
 
 declare const Downshift: DownshiftInterface<any>
 export default Downshift
+export function resetIdCounter(): void


### PR DESCRIPTION
I'm not a TS user, but this was reported and it seems to me that this is easy enough to add it right away 