### PR TITLE
fix type for itemToString

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -31,7 +31,7 @@ export interface DownshiftProps<Item> {
   defaultHighlightedIndex?: number | null
   defaultInputValue?: string
   defaultIsOpen?: boolean
-  itemToString?: (item: Item) => string
+  itemToString?: (item: Item | null) => string
   selectedItemChanged?: (prevItem: Item, item: Item) => boolean
   getA11yStatusMessage?: (options: A11yStatusMessageOptions<Item>) => string
   onChange?: (


### PR DESCRIPTION
As per your [`README.md`](https://github.com/paypal/downshift#itemtostring), `itemToString` can be called with a null `Item`. 

> `function(item: any)` | defaults to: `i => (i == null ? '' : String(i))`

This PR fixes your typings to reflect that. 


