### PR TITLE
Replace native dispatchEvent with fireEvent from react-testing-library

### DIFF
--- a/src/__tests__/downshift.get-button-props.js
+++ b/src/__tests__/downshift.get-button-props.js
@@ -53,9 +53,7 @@ test('on button blur does not reset the state when the mouse is down', () => {
   const {button, childrenSpy} = setup()
   childrenSpy.mockClear()
   // mousedown somwhere
-  document.body.dispatchEvent(
-    new window.MouseEvent('mousedown', {bubbles: true}),
-  )
+  fireEvent.mouseDown(document.body)
   fireEvent.blur(button)
   jest.runAllTimers()
   expect(childrenSpy).not.toHaveBeenCalled()

--- a/src/__tests__/downshift.get-input-props.js
+++ b/src/__tests__/downshift.get-input-props.js
@@ -178,9 +178,7 @@ test('on input blur resets the state', () => {
 test('on input blur does not reset the state when the mouse is down', () => {
   const {blurOnInput, childrenSpy} = setupDownshiftWithState()
   // mousedown somwhere
-  document.body.dispatchEvent(
-    new window.MouseEvent('mousedown', {bubbles: true}),
-  )
+  fireEvent.mouseDown(document.body)
   blurOnInput()
   jest.runAllTimers()
   expect(childrenSpy).not.toHaveBeenCalled()

--- a/src/__tests__/downshift.lifecycle.js
+++ b/src/__tests__/downshift.lifecycle.js
@@ -86,9 +86,7 @@ test('handles state change for touchevent events', () => {
   const button = queryByTestId('button')
 
   // touch outside for coverage
-  document.body.dispatchEvent(
-    new window.TouchEvent('touchstart', {bubbles: true}),
-  )
+  fireEvent.touchStart(document.body)
 
   // open menu
   fireEvent.click(button)
@@ -97,9 +95,7 @@ test('handles state change for touchevent events', () => {
   expect(handleStateChange).toHaveBeenCalledTimes(1)
 
   // touch outside downshift
-  document.body.dispatchEvent(
-    new window.TouchEvent('touchstart', {bubbles: true}),
-  )
+  fireEvent.touchStart(document.body)
 
   jest.runAllTimers()
   expect(handleStateChange).toHaveBeenCalledTimes(2)
@@ -266,8 +262,8 @@ test('controlled highlighted index change scrolls the item into view', () => {
 })
 
 function mouseDownAndUp(node) {
-  node.dispatchEvent(new window.MouseEvent('mousedown', {bubbles: true}))
-  node.dispatchEvent(new window.MouseEvent('mouseup', {bubbles: true}))
+  fireEvent.mouseDown(node)
+  fireEvent.mouseUp(node)
 }
 
 function setup({render: renderFn = () => <div />, ...props} = {}) {

--- a/src/__tests__/downshift.misc.js
+++ b/src/__tests__/downshift.misc.js
@@ -1,6 +1,7 @@
 // this is stuff that I couldn't think fit anywhere else
 // but we still want to have tested.
 
+import 'react-testing-library/cleanup-after-each'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import {render} from 'react-testing-library'

--- a/src/__tests__/downshift.props.js
+++ b/src/__tests__/downshift.props.js
@@ -2,7 +2,7 @@
 // but we still want to have tested.
 
 import React from 'react'
-import {render} from 'react-testing-library'
+import {render, fireEvent} from 'react-testing-library'
 import Downshift from '../'
 
 test('onStateChange called with changes and downshift state and helpers', () => {
@@ -182,8 +182,8 @@ test('stateReducer customizes the final state after keyDownEnter handled', () =>
 })
 
 function mouseDownAndUp(node) {
-  node.dispatchEvent(new window.MouseEvent('mousedown', {bubbles: true}))
-  node.dispatchEvent(new window.MouseEvent('mouseup', {bubbles: true}))
+  fireEvent.mouseDown(node)
+  fireEvent.mouseUp(node)
 }
 
 function setup({render: renderFn = () => <div />, ...props} = {}) {

--- a/src/__tests__/downshift.props.js
+++ b/src/__tests__/downshift.props.js
@@ -1,6 +1,7 @@
 // this is stuff that I couldn't think fit anywhere else
 // but we still want to have tested.
 
+import 'react-testing-library/cleanup-after-each'
 import React from 'react'
 import {render, fireEvent} from 'react-testing-library'
 import Downshift from '../'


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Replace the usage of `dispatchEvent` with `fireEvent` from `react-testing-library`
<!-- Why are these changes necessary? -->

**Why**:
Being consistent and I can't think of any reason why we need to keep `dispatchEvent`
<!-- How were these changes implemented? -->

**How**:
Pretty much just replacing the `dispatchEvent` with the equivalent of `fireEvent`. Bit unsure about bubbling but `react-testing-library` seems to take care of that.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
