### PR TITLE
Refactor timeout handling on unmount

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -56,16 +56,24 @@ function isOrContainsNode(parent, child) {
  */
 function debounce(fn, time) {
   let timeoutId
-  return wrapper
-  function wrapper(...args) {
+
+  function cancel() {
     if (timeoutId) {
       clearTimeout(timeoutId)
     }
+  }
+
+  function wrapper(...args) {
+    cancel()
     timeoutId = setTimeout(() => {
       timeoutId = null
       fn(...args)
     }, time)
   }
+
+  wrapper.cancel = cancel
+
+  return wrapper
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Refactor timeout handling when unmounting. Instead of using `_isMounted` we now clear the timeouts.
<!-- Why are these changes necessary? -->

**Why**:
In my opinion this solution is a more "correct", and probably less error prone way to solve the problem. Now we actually fix the root cause and not the "symptom" (`setState` being called on unmounted components). React has an official [blog post](https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html) about this as well. 

<!-- How were these changes implemented? -->

**How**:
I created 2 new instance functions, `internalSetTimeout` and `internalClearTimeouts`. `internaltSetTimeout` is a wrapper around `setTimeout` that pushes the `timeoutId` to an array and removes it when the `setTimeout` callback fires. 

`internalClearTimeouts` loops through all `timeoutIds` and clears them with `clearTimeout`.

Not entirely sure about the naming, is simply `this.setTimeout` better? My reasoning behind `internalSetTimout` was that it would become more clear that it's a wrapper that does more than the native `setTimeout`.

I also added support for cancellation in the `debounce` utils function.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
