### PR TITLE
docs: add link to downshift-examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -888,7 +888,12 @@ platforms:
 
 ## Examples
 
-Examples exist on [codesandbox.io][examples]:
+> 🚨 We're in the process of moving all examples to the
+> [downshift-examples](https://github.com/kentcdodds/downshift-examples) repo
+> (which you can open, interact with, and contribute back to live on
+> [codesandbox](https://codesandbox.io/s/github/kentcdodds/downshift-examples))
+
+Old Examples exist on [codesandbox.io][examples]:
 
 - [Bare bones autocomplete](https://codesandbox.io/s/6z67jvklw3)
 - [Multiple selection](https://codesandbox.io/s/W6gyJ30kn) (uses controlled


### PR DESCRIPTION
**What**: Add link to downshift-examples in the README

**Why**: Because I don't think many people know about these examples and that's where examples should be put.

**How**: Updated the README with a note. Eventually we should entirely replace this section with links directly to modules in that codesandbox, but [that functionality is broken right now](https://github.com/CompuIves/codesandbox-client/issues/989)

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
