### PR TITLE
Replace deprecated toBeInDOM method

### DIFF
--- a/src/__tests__/portal-support.js
+++ b/src/__tests__/portal-support.js
@@ -55,9 +55,9 @@ test('will not reset when clicking within the menu', () => {
     )
   }
   const {getByTestId, queryByTestId} = render(<MyPortalAutocomplete />)
-  expect(queryByTestId('menu')).not.toBeInTheDOM()
+  expect(queryByTestId('menu')).toBeNull()
   getByTestId('button').click()
-  expect(getByTestId('menu')).toBeInTheDOM()
+  expect(getByTestId('menu')).toBeInstanceOf(HTMLElement)
 
   const notAnItem = getByTestId('not-an-item')
 
@@ -65,14 +65,14 @@ test('will not reset when clicking within the menu', () => {
   fireEvent.mouseDown(notAnItem)
   notAnItem.focus() // sets document.activeElement
   fireEvent.mouseUp(notAnItem)
-  expect(getByTestId('menu')).toBeInTheDOM()
+  expect(getByTestId('menu')).toBeInstanceOf(HTMLElement)
 
   // Touch events
   fireEvent.touchStart(notAnItem)
   notAnItem.focus() // sets document.activeElement
-  expect(getByTestId('menu')).toBeInTheDOM()
+  expect(getByTestId('menu')).toBeInstanceOf(HTMLElement)
 
   getByTestId('item').click()
-  expect(queryByTestId('menu')).not.toBeInTheDOM()
+  expect(queryByTestId('menu')).toBeNull()
   expect(getByTestId('selection')).toHaveTextContent('The item')
 })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Replace deprecated `jest-dom` method
<!-- Why are these changes necessary? -->

**Why**:
`toBeInDOM` is deprecated
https://github.com/gnapse/jest-dom/issues/34
<!-- How were these changes implemented? -->

**How**:
Replace deprecated `toBeInDOM` with `toBeNull` and/or `toBeInstanceOf`
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
