### PR TITLE
Validate that getMenuProps has set the ref correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ overridden (or overriding the props returned). For example:
 | `getInputProps`        | `function({})`    | returns the props you should apply to the `input` element that you render.                     |
 | `getItemProps`         | `function({})`    | returns the props you should apply to any menu item elements you render.                       |
 | `getLabelProps`        | `function({})`    | returns the props you should apply to the `label` element that you render.                     |
-| `getMenuProps`         | `function({})`    | returns the props you should apply to the `ul` element (or root of your menu) that you render. |
+| `getMenuProps`         | `function({},{})` | returns the props you should apply to the `ul` element (or root of your menu) that you render. |
 | `getRootProps`         | `function({},{})` | returns the props you should apply to the root element that you render. It can be optional.    |
 
 #### `getRootProps`
@@ -627,6 +627,13 @@ This method should be applied to the element which contains your list of items.
 Typically, this will be a `<div>` or a `<ul>` that surrounds a `map` expression.
 This handles the proper ARIA roles and attributes.
 
+Required properties:
+
+- `refKey`: if you're rendering a composite component, that component will need
+  to accept a prop which it forwards to the root DOM element. Commonly, folks
+  call this `innerRef`. So you'd call: `getMenuProps({refKey: 'innerRef'})` and
+  your composite component would forward like: `<ul ref={props.innerRef} />`
+
 Optional properties:
 
 - `aria-label`: By default the menu will add an `aria-labelledby` that refers
@@ -634,6 +641,12 @@ Optional properties:
   `aria-label` to give a more specific label that describes the options
   available, then `aria-labelledby` will not be provided and screen readers
   can use your `aria-label` instead.
+
+In some cases, you might want to completely bypass the `refKey` check. Then you
+can provide the object `{suppressRefError : true}` as the second argument to
+`getMenuProps`.
+**Please use it with extreme care and only if you are absolutely sure that the ref
+is correctly forwarded otherwise `Downshift` will unexpectedly fail.**
 
 ```jsx
 <ul {...getMenuProps()}>
@@ -912,7 +925,7 @@ Check out these examples of more advanced use/edge cases:
 
 **Old Examples exist on [codesandbox.io][examples]:**
 
-*🚨 This is a great contribution opportunity!* These are examples that have not yet been migrated to
+_🚨 This is a great contribution opportunity!_ These are examples that have not yet been migrated to
 [downshift-examples](https://codesandbox.io/s/github/kentcdodds/downshift-examples).
 You're more than welcome to make PRs to the examples repository to move these examples over there.
 [Watch this to learn how to contribute completely in the browser](https://www.youtube.com/watch?v=3PAQbhdkTtI&index=2&t=21s&list=PLV5CVI1eNcJgCrPH_e6d57KRUTiDZgs0u)

--- a/src/__tests__/__snapshots__/downshift.get-menu-props.js.snap
+++ b/src/__tests__/__snapshots__/downshift.get-menu-props.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`not applying the ref prop results in an error 1`] = `"downshift: The ref prop \\"ref\\" from getMenuProps was not applied correctly on your menu element."`;
+
+exports[`using a composite component and calling getMenuProps without a refKey results in an error 1`] = `"downshift: The ref prop \\"ref\\" from getMenuProps was not applied correctly on your menu element."`;

--- a/src/__tests__/downshift.get-menu-props.js
+++ b/src/__tests__/downshift.get-menu-props.js
@@ -1,0 +1,114 @@
+import React from 'react'
+import {render} from 'react-testing-library'
+import Downshift from '../'
+
+const oldError = console.error
+
+beforeEach(() => {
+  console.error = jest.fn()
+})
+
+afterEach(() => {
+  console.error = oldError
+})
+
+const Menu = ({innerRef, ...rest}) => <div ref={innerRef} {...rest} />
+
+test('using a composite component and calling getMenuProps without a refKey results in an error', () => {
+  const MyComponent = () => (
+    <Downshift
+      children={({getMenuProps}) => (
+        <div>
+          <Menu {...getMenuProps()} />
+        </div>
+      )}
+    />
+  )
+  expect(() => render(<MyComponent />)).toThrowErrorMatchingSnapshot()
+})
+
+test('not applying the ref prop results in an error', () => {
+  const MyComponent = () => (
+    <Downshift
+      children={({getMenuProps}) => {
+        getMenuProps()
+        return (
+          <div>
+            <ul />
+          </div>
+        )
+      }}
+    />
+  )
+  expect(() => render(<MyComponent />)).toThrowErrorMatchingSnapshot()
+})
+
+test('renders fine when rendering a composite component and applying getMenuProps properly', () => {
+  const MyComponent = () => (
+    <Downshift
+      children={({getMenuProps}) => (
+        <div>
+          <Menu {...getMenuProps({refKey: 'innerRef'})} />
+        </div>
+      )}
+    />
+  )
+  expect(() => render(<MyComponent />)).not.toThrow()
+})
+
+test('using a composite component and calling getMenuProps without a refKey does not result in an error if suppressRefError is true', () => {
+  const MyComponent = () => (
+    <Downshift
+      children={({getMenuProps}) => (
+        <div>
+          <Menu {...getMenuProps({}, {suppressRefError: true})} />
+        </div>
+      )}
+    />
+  )
+  expect(() => render(<MyComponent />)).not.toThrow()
+})
+
+test('returning a DOM element and calling getMenuProps with a refKey does not result in an error if suppressRefError is true', () => {
+  const MyComponent = () => (
+    <Downshift
+      children={({getMenuProps}) => (
+        <div>
+          <ul {...getMenuProps({refKey: 'blah'}, {suppressRefError: true})} />
+        </div>
+      )}
+    />
+  )
+  expect(() => render(<MyComponent />)).not.toThrow()
+})
+
+test('not applying the ref prop results in an error does not result in an error if suppressRefError is true', () => {
+  const MyComponent = () => (
+    <Downshift
+      children={({getMenuProps}) => {
+        getMenuProps({}, {suppressRefError: true})
+        return (
+          <div>
+            <ul />
+          </div>
+        )
+      }}
+    />
+  )
+  expect(() => render(<MyComponent />)).not.toThrow()
+})
+
+test('renders fine when rendering a composite component and applying getMenuProps properly even if suppressRefError is true', () => {
+  const MyComponent = () => (
+    <Downshift
+      children={({getMenuProps}) => (
+        <div>
+          <Menu
+            {...getMenuProps({refKey: 'innerRef'}, {suppressRefError: true})}
+          />
+        </div>
+      )}
+    />
+  )
+  expect(() => render(<MyComponent />)).not.toThrow()
+})

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -780,7 +780,14 @@ class Downshift extends Component {
 
   menuRef = node => (this._menuNode = node)
 
-  getMenuProps = ({refKey = 'ref', ref, ...props} = {}) => {
+  getMenuProps = (
+    {refKey = 'ref', ref, ...props} = {},
+    {suppressRefError = false} = {},
+  ) => {
+    this.getMenuProps.called = true
+    this.getMenuProps.refKey = refKey
+    this.getMenuProps.suppressRefError = suppressRefError
+
     return {
       [refKey]: callAll(ref, this.menuRef),
       role: 'listbox',
@@ -918,6 +925,10 @@ class Downshift extends Component {
   }, 200)
 
   componentDidMount() {
+    if (this.getMenuProps.called && !this.getMenuProps.suppressRefError) {
+      validateGetMenuPropsCalledCorrectly(this._menuNode, this.getMenuProps)
+    }
+
     /* istanbul ignore if (react-native) */
     if (preval`module.exports = process.env.BUILD_REACT_NATIVE === 'true'`) {
       this.cleanup = () => {
@@ -983,6 +994,10 @@ class Downshift extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
+    if (this.getMenuProps.called && !this.getMenuProps.suppressRefError) {
+      validateGetMenuPropsCalledCorrectly(this._menuNode, this.getMenuProps)
+    }
+
     if (
       this.isControlledProp('selectedItem') &&
       this.props.selectedItemChanged(
@@ -1031,6 +1046,10 @@ class Downshift extends Component {
     this.getRootProps.called = false
     this.getRootProps.refKey = undefined
     this.getRootProps.suppressRefError = undefined
+    // we do something similar for getMenuProps
+    this.getMenuProps.called = false
+    this.getMenuProps.refKey = undefined
+    this.getMenuProps.suppressRefError = undefined
     // we do something similar for getLabelProps
     this.getLabelProps.called = false
     // and something similar for getInputProps
@@ -1062,6 +1081,14 @@ class Downshift extends Component {
 }
 
 export default Downshift
+
+function validateGetMenuPropsCalledCorrectly(node, {refKey}) {
+  if (!node) {
+    throw new Error(
+      `downshift: The ref prop "${refKey}" from getMenuProps was not applied correctly on your menu element.`,
+    )
+  }
+}
 
 function validateGetRootPropsCalledCorrectly(element, {refKey}) {
   const refKeySpecified = refKey !== 'ref'

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -928,7 +928,7 @@ class Downshift extends Component {
     if (
       this.getMenuProps.called &&
       !this.getMenuProps.suppressRefError &&
-      preval`module.exports = process.env.BUILD_REACT_NATIVE !== 'true'`
+      /* istanbul ignore next (react-native) */ preval`module.exports = process.env.BUILD_REACT_NATIVE !== 'true'`
     ) {
       validateGetMenuPropsCalledCorrectly(this._menuNode, this.getMenuProps)
     }
@@ -1001,7 +1001,7 @@ class Downshift extends Component {
     if (
       this.getMenuProps.called &&
       !this.getMenuProps.suppressRefError &&
-      preval`module.exports = process.env.BUILD_REACT_NATIVE !== 'true'`
+      /* istanbul ignore next (react-native) */ preval`module.exports = process.env.BUILD_REACT_NATIVE !== 'true'`
     ) {
       validateGetMenuPropsCalledCorrectly(this._menuNode, this.getMenuProps)
     }

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -925,7 +925,11 @@ class Downshift extends Component {
   }, 200)
 
   componentDidMount() {
-    if (this.getMenuProps.called && !this.getMenuProps.suppressRefError) {
+    if (
+      this.getMenuProps.called &&
+      !this.getMenuProps.suppressRefError &&
+      preval`module.exports = process.env.BUILD_REACT_NATIVE !== 'true'`
+    ) {
       validateGetMenuPropsCalledCorrectly(this._menuNode, this.getMenuProps)
     }
 
@@ -994,7 +998,11 @@ class Downshift extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    if (this.getMenuProps.called && !this.getMenuProps.suppressRefError) {
+    if (
+      this.getMenuProps.called &&
+      !this.getMenuProps.suppressRefError &&
+      preval`module.exports = process.env.BUILD_REACT_NATIVE !== 'true'`
+    ) {
       validateGetMenuPropsCalledCorrectly(this._menuNode, this.getMenuProps)
     }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Fixes #490 by using the same approach as we do in `getRootProps`.
<!-- Why are these changes necessary? -->

**Why**:
Because it could lead to unexpected behavior and to avoid confusion.

<!-- How were these changes implemented? -->

**How**:
I'm still unsure of what the best solution for this is. I would like to make the check in the `render` method as we do for the `getRootProps`, but I don't think that's possible because the ref hasn't set `this._menuNode` on the first render. I guess we could loop through all children but that seems unnecessary heavy/slow.

So instead I make the validation/check in `componentDidUpdate`, which looks to work fine.

Another problem I encountered was that there is no way to check if `this._menuNode` is a composite element or not, which makes it hard to use the same validation as we do for `getRootProps`.

I wanted you opinion on this before I continue and add tests and update the documentation. Is there another better way that I've not thought of?

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
