### PR TITLE
perf: Call `super` with only props instead of ...args

### DIFF
--- a/src/downshift.js
+++ b/src/downshift.js
@@ -122,8 +122,8 @@ class Downshift extends Component {
     touchStart: '__autocomplete_touchstart__',
   }
 
-  constructor(...args) {
-    super(...args)
+  constructor(props) {
+    super(props)
     const state = this.getState({
       highlightedIndex: this.props.defaultHighlightedIndex,
       isOpen: this.props.defaultIsOpen,


### PR DESCRIPTION
**This is small output size optimization.**

The only thing needed for `super` here is `props`. So we can just call it with them instead of whole `args`. Because `args` have variadic length the transpiled code has to iterate through `arguments` to create them and we can prevent emitting this `for` loop.

