### PR TITLE
Improved typings for getMenuProps

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -111,7 +111,7 @@ export interface GetToggleButtonPropsOptions
 export interface GetMenuPropsOptions<Item>
   extends Record<string, any> {
   refKey?: string;
-};
+}
 
 export interface GetMenuPropsOtherOptions<Item> {
   suppressRefError?: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -108,12 +108,12 @@ export interface GetLabelPropsOptions
 export interface GetToggleButtonPropsOptions
   extends React.HTMLProps<HTMLButtonElement> {}
 
-export interface GetMenuPropsOptions<Item>
-  extends Record<string, any> {
+export interface GetMenuPropsOptions {
   refKey?: string;
-}
+  ['aria-label']?: string;
+};
 
-export interface GetMenuPropsOtherOptions<Item> {
+export interface GetMenuPropsOtherOptions {
   suppressRefError?: boolean;
 }
 
@@ -127,7 +127,7 @@ export interface PropGetters<Item> {
   getRootProps: (options: GetRootPropsOptions) => any
   getToggleButtonProps: (options?: GetToggleButtonPropsOptions) => any
   getLabelProps: (options?: GetLabelPropsOptions) => any
-  getMenuProps: (options?: GetMenuPropsOptions<Item>, otherOptions?: GetMenuPropsOtherOptions<Item>) => any
+  getMenuProps: (options?: GetMenuPropsOptions, otherOptions?: GetMenuPropsOtherOptions) => any
   getInputProps: (options?: GetInputPropsOptions) => any
   getItemProps: (options: GetItemPropsOptions<Item>) => any
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -127,7 +127,7 @@ export interface PropGetters<Item> {
   getRootProps: (options: GetRootPropsOptions) => any
   getToggleButtonProps: (options?: GetToggleButtonPropsOptions) => any
   getLabelProps: (options?: GetLabelPropsOptions) => any
-  getMenuProps: (options?: GetMenuPropsOptions, otherOptions?: GetMenuPropsOtherOptions) => any
+  getMenuProps: (options?: GetMenuPropsOptions<Item>, otherOptions?: GetMenuPropsOtherOptions<Item>) => any
   getInputProps: (options?: GetInputPropsOptions) => any
   getItemProps: (options: GetItemPropsOptions<Item>) => any
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -105,24 +105,29 @@ export interface GetInputPropsOptions
 export interface GetLabelPropsOptions
   extends React.HTMLProps<HTMLLabelElement> {}
 
-export interface getToggleButtonPropsOptions
+export interface GetToggleButtonPropsOptions
   extends React.HTMLProps<HTMLButtonElement> {}
 
-interface OptionalExtraGetItemPropsOptions {
-  [key: string]: any
+export interface GetMenuPropsOptions<Item>
+  extends Record<string, any> {
+  refKey?: string;
+};
+
+export interface GetMenuPropsOtherOptions<Item> {
+  suppressRefError?: boolean;
 }
 
 export interface GetItemPropsOptions<Item>
-  extends OptionalExtraGetItemPropsOptions {
+  extends Record<string, any> {
   index?: number
   item: Item
 }
 
 export interface PropGetters<Item> {
   getRootProps: (options: GetRootPropsOptions) => any
-  getToggleButtonProps: (options?: getToggleButtonPropsOptions) => any
+  getToggleButtonProps: (options?: GetToggleButtonPropsOptions) => any
   getLabelProps: (options?: GetLabelPropsOptions) => any
-  getMenuProps: (options?: {}) => any
+  getMenuProps: (options?: GetMenuPropsOptions, otherOptions?: GetMenuPropsOtherOptions) => any
   getInputProps: (options?: GetInputPropsOptions) => any
   getItemProps: (options: GetItemPropsOptions<Item>) => any
 }


### PR DESCRIPTION
Fixes the typing part of #490

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->


<!-- Why are these changes necessary? -->

**Why**: The typings for `getMenuProps` was too broad.

<!-- How were these changes implemented? -->

**How**:
Created interfaces for the types of parameters of `getMenuProps`
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
