### PR TITLE
feat(scrollIntoView): add new prop to override built-in scrollIntoView

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "preact/dist/downshift.cjs.js": {
-    "bundled": 55985,
-    "minified": 23755,
-    "gzipped": 7059
+    "bundled": 56030,
+    "minified": 23804,
+    "gzipped": 7068
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 58032,
-    "minified": 21519,
-    "gzipped": 6612
+    "bundled": 58079,
+    "minified": 21567,
+    "gzipped": 6626
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 58668,
-    "minified": 21867,
-    "gzipped": 6747
+    "bundled": 58715,
+    "minified": 21915,
+    "gzipped": 6762
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 61008,
-    "minified": 22733,
-    "gzipped": 7167
+    "bundled": 63274,
+    "minified": 23314,
+    "gzipped": 7396
   },
   "dist/downshift.cjs.js": {
     "bundled": 85379,

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ harder to contribute to.
   - [getItemId](#getitemid)
   - [environment](#environment)
   - [onOuterClick](#onouterclick)
+  - [scrollIntoView](#scrollintoview)
 - [stateChangeTypes](#statechangetypes)
 - [Control Props](#control-props)
 - [Children Function](#children-function)
@@ -482,6 +483,18 @@ const ui = (
 
 This callback will only be called if `isOpen` is `true`.
 
+### scrollIntoView
+
+> `function(node: HTMLElement, rootNode: HTMLElement)` | defaults to internal
+> implementation
+
+This allows you to customize how the scrolling works when the highlighted index
+changes. It receives the node to be scrolled to and the root node (the root
+node you render in downshift). Internally we use
+[`compute-scroll-into-view`](https://www.npmjs.com/package/compute-scroll-into-view)
+so if you use that package then you wont be adding any additional bytes to your
+bundle :)
+
 ## stateChangeTypes
 
 There are a few props that expose changes to state
@@ -635,7 +648,7 @@ Optional properties:
   your composite component would forward like: `<ul ref={props.innerRef} />`.
   However, if you are just rendering a primitive component like `<div>`, there
   is no need to specify this property.
-  
+
   Please keep in mind that menus, for accessiblity purposes, should always be
   rendered, regardless of whether you hide it or not. Otherwise, `getMenuProps`
   may throw error if you unmount and remount the menu.

--- a/src/__tests__/downshift.lifecycle.js
+++ b/src/__tests__/downshift.lifecycle.js
@@ -7,6 +7,17 @@ import * as utils from '../utils'
 
 jest.useFakeTimers()
 jest.mock('../set-a11y-status')
+jest.mock('../utils', () => {
+  const realUtils = require.requireActual('../utils')
+  return {
+    ...realUtils,
+    scrollIntoView: jest.fn(),
+  }
+})
+
+afterEach(() => {
+  utils.scrollIntoView.mockReset()
+})
 
 test('do not set state after unmount', () => {
   const handleStateChange = jest.fn()
@@ -233,7 +244,6 @@ test('controlled highlighted index change scrolls the item into view', () => {
   // utils.scrollIntoView and ensure it's called with the proper arguments
   // assuming that the test suite for utils.scrollIntoView will ensure
   // this functionality doesn't break.
-  jest.spyOn(utils, 'scrollIntoView').mockImplementation(() => {})
   const oneHundredItems = Array.from({length: 100})
   const renderFn = jest.fn(({getItemProps}) => (
     <div data-testid="root">
@@ -257,8 +267,6 @@ test('controlled highlighted index change scrolls the item into view', () => {
     queryByTestId('item-75'),
     rootDiv,
   )
-
-  utils.scrollIntoView.mockRestore()
 })
 
 function mouseDownAndUp(node) {

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -52,6 +52,7 @@ class Downshift extends Component {
       }),
     }),
     suppressRefError: PropTypes.bool,
+    scrollIntoView: PropTypes.func,
     // things we keep in state for uncontrolled components
     // but can accept as props for controlled components
     /* eslint-disable react/no-unused-prop-types */
@@ -103,6 +104,7 @@ class Downshift extends Component {
         : window,
     stateReducer: (state, stateToSet) => stateToSet,
     suppressRefError: false,
+    scrollIntoView,
   }
 
   static stateChangeTypes = {
@@ -248,7 +250,7 @@ class Downshift extends Component {
     /* istanbul ignore else (react-native) */
     if (preval`module.exports = process.env.BUILD_REACT_NATIVE !== 'true'`) {
       const node = this.getItemNodeFromIndex(this.getState().highlightedIndex)
-      scrollIntoView(node, this._rootNode)
+      this.props.scrollIntoView(node, this._rootNode)
     }
   }
 


### PR DESCRIPTION
**What**: feat(scrollIntoView): add new prop to override built-in scrollIntoView

<!-- Why are these changes necessary? -->

**Why**: Closes #537

<!-- How were these changes implemented? -->

**How**: React makes this easy. I leverage `defaultProps` to set our own implementation of `scrollIntoView` as the `scrollIntoView` prop and then call it via `this.props.scrollIntoView` so users of downshift can override it to be whatever they want.

This means that I had to change the test slightly because the `scrollIntoView` function is no longer called directly on `utils` so we can't spy on it. Just swapped that to use mocking and it's working fine.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
