### PR TITLE
chore: inline build variables with custom simple macro

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 registry=http://registry.npmjs.org/
+package-lock=false

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,59 +1,59 @@
 {
   "preact/dist/downshift.cjs.js": {
-    "bundled": 48940,
-    "minified": 21522,
-    "gzipped": 6170
+    "bundled": 48810,
+    "minified": 21477,
+    "gzipped": 6159
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 58273,
-    "minified": 21511,
-    "gzipped": 6641
+    "bundled": 58137,
+    "minified": 21466,
+    "gzipped": 6629
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 63437,
-    "minified": 23258,
-    "gzipped": 7421
+    "bundled": 63167,
+    "minified": 23204,
+    "gzipped": 7404
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 58909,
-    "minified": 21859,
-    "gzipped": 6776
+    "bundled": 58773,
+    "minified": 21814,
+    "gzipped": 6764
   },
   "dist/downshift.cjs.js": {
-    "bundled": 50424,
-    "minified": 22611,
-    "gzipped": 6368
+    "bundled": 50161,
+    "minified": 22557,
+    "gzipped": 6351
   },
   "dist/downshift.umd.js": {
-    "bundled": 88797,
-    "minified": 31332,
-    "gzipped": 9792
+    "bundled": 88527,
+    "minified": 31278,
+    "gzipped": 9777
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 48660,
-    "minified": 21299,
-    "gzipped": 6102,
+    "bundled": 48530,
+    "minified": 21254,
+    "gzipped": 6091,
     "treeshaked": {
       "rollup": {
-        "code": 19009,
+        "code": 18964,
         "import_statements": 78
       },
       "webpack": {
-        "code": 20032
+        "code": 19987
       }
     }
   },
   "dist/downshift.esm.js": {
-    "bundled": 50124,
-    "minified": 22373,
-    "gzipped": 6303,
+    "bundled": 49861,
+    "minified": 22319,
+    "gzipped": 6284,
     "treeshaked": {
       "rollup": {
-        "code": 19028,
+        "code": 18974,
         "import_statements": 96
       },
       "webpack": {
-        "code": 20086
+        "code": 20032
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   "devDependencies": {
     "@storybook/react": "^3.4.7",
     "@types/react": "^16.0.40",
+    "babel-plugin-macros": "^2.4.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react-native": "^4.0.0",
     "cross-env": "^5.1.4",

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -2,7 +2,7 @@
 
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
-import preval from 'preval.macro'
+import {isPreact, isReactNative} from './is.macro'
 import setA11yStatus from './set-a11y-status'
 import * as stateChangeTypes from './stateChangeTypes'
 import {
@@ -232,7 +232,7 @@ class Downshift extends Component {
 
   scrollHighlightedItemIntoView() {
     /* istanbul ignore else (react-native) */
-    if (preval`module.exports = process.env.BUILD_REACT_NATIVE !== 'true'`) {
+    if (!isReactNative) {
       const node = this.getItemNodeFromIndex(this.getState().highlightedIndex)
       this.props.scrollIntoView(node, this._rootNode)
     }
@@ -574,7 +574,7 @@ class Downshift extends Component {
     ...rest
   } = {}) => {
     const {isOpen} = this.getState()
-    const enabledEventHandlers = preval`module.exports = process.env.BUILD_REACT_NATIVE === 'true'`
+    const enabledEventHandlers = isReactNative
       ? /* istanbul ignore next (react-native) */
         {
           onPress: callAllEventHandlers(onPress, this.button_handleClick),
@@ -672,7 +672,7 @@ class Downshift extends Component {
     let eventHandlers = {}
 
     /* istanbul ignore next (preact) */
-    if (preval`module.exports = process.env.BUILD_PREACT === 'true'`) {
+    if (isPreact) {
       onChangeKey = 'onInput'
     } else {
       onChangeKey = 'onChange'
@@ -692,7 +692,7 @@ class Downshift extends Component {
     }
 
     /* istanbul ignore if (react-native) */
-    if (preval`module.exports = process.env.BUILD_REACT_NATIVE === 'true'`) {
+    if (isReactNative) {
       eventHandlers = {
         ...eventHandlers,
         onChangeText: callAllEventHandlers(
@@ -732,7 +732,7 @@ class Downshift extends Component {
     this.internalSetState({
       type: stateChangeTypes.changeInput,
       isOpen: true,
-      inputValue: preval`module.exports = process.env.BUILD_REACT_NATIVE === 'true'`
+      inputValue: isReactNative
         ? /* istanbul ignore next (react-native) */ event.nativeEvent.text
         : event.target.value,
     })
@@ -802,10 +802,10 @@ class Downshift extends Component {
       this.items[index] = item
     }
 
-    const onSelectKey = preval`module.exports = process.env.BUILD_REACT_NATIVE === 'true'`
+    const onSelectKey = isReactNative
       ? /* istanbul ignore next (react-native) */ 'onPress'
       : 'onClick'
-    const customClickHandler = preval`module.exports = process.env.BUILD_REACT_NATIVE === 'true'`
+    const customClickHandler = isReactNative
       ? /* istanbul ignore next (react-native) */ onPress
       : onClick
 
@@ -912,16 +912,17 @@ class Downshift extends Component {
   }, 200)
 
   componentDidMount() {
+    /* istanbul ignore if (react-native) */
     if (
+      !isReactNative &&
       this.getMenuProps.called &&
-      !this.getMenuProps.suppressRefError &&
-      /* istanbul ignore next (react-native) */ preval`module.exports = process.env.BUILD_REACT_NATIVE !== 'true'`
+      !this.getMenuProps.suppressRefError
     ) {
       validateGetMenuPropsCalledCorrectly(this._menuNode, this.getMenuProps)
     }
 
     /* istanbul ignore if (react-native) */
-    if (preval`module.exports = process.env.BUILD_REACT_NATIVE === 'true'`) {
+    if (isReactNative) {
       this.cleanup = () => {
         this.internalClearTimeouts()
       }
@@ -986,9 +987,9 @@ class Downshift extends Component {
 
   componentDidUpdate(prevProps, prevState) {
     if (
+      /* istanbul ignore next (react-native) */ !isReactNative &&
       this.getMenuProps.called &&
-      !this.getMenuProps.suppressRefError &&
-      /* istanbul ignore next (react-native) */ preval`module.exports = process.env.BUILD_REACT_NATIVE !== 'true'`
+      !this.getMenuProps.suppressRefError
     ) {
       validateGetMenuPropsCalledCorrectly(this._menuNode, this.getMenuProps)
     }
@@ -1019,7 +1020,7 @@ class Downshift extends Component {
     }
 
     /* istanbul ignore else (react-native) */
-    if (preval`module.exports = process.env.BUILD_REACT_NATIVE !== 'true'`) {
+    if (!isReactNative) {
       this.updateStatus()
     }
   }

--- a/src/is.macro.js
+++ b/src/is.macro.js
@@ -1,0 +1,34 @@
+/* istanbul ignore next */
+const {createMacro, MacroError} = require('babel-plugin-macros')
+
+/* istanbul ignore next */
+module.exports = createMacro(({references, babel: {types: t}}) => {
+  const importToEnvVar = {
+    isPreact: 'BUILD_PREACT',
+    isReactNative: 'BUILD_REACT_NATIVE',
+  }
+
+  const arrToStr = arr => arr.join(', ')
+
+  const usedReferences = Object.keys(references)
+  const allowedReferences = Object.keys(importToEnvVar)
+
+  if (usedReferences.filter(ref => !importToEnvVar[ref]).length !== 0) {
+    throw new MacroError(
+      `${__filename} handles only those named exports: ${arrToStr(
+        allowedReferences,
+      )}, you have tried to use it with: ${arrToStr(usedReferences)}.`,
+    )
+  }
+
+  usedReferences.forEach(refName => {
+    const envVar = importToEnvVar[refName]
+
+    references[refName].forEach(usedRef => {
+      const envValue = process.env[envVar]
+      usedRef.replaceWith(
+        t.booleanLiteral((envValue && envValue !== 'false') || false),
+      )
+    })
+  })
+})

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 import computeScrollIntoView from 'compute-scroll-into-view'
+import {isPreact} from './is.macro'
 
 let idCounter = 0
 
@@ -189,13 +190,13 @@ function unwrapArray(arg, defaultValue) {
  */
 function isDOMElement(element) {
   /* istanbul ignore if */
-  if (element.nodeName) {
+  if (isPreact) {
     // then this is preact
     return typeof element.nodeName === 'string'
-  } else {
-    // then we assume this is react
-    return typeof element.type === 'string'
   }
+
+  // then we assume this is react
+  return typeof element.type === 'string'
 }
 
 /**
@@ -204,7 +205,13 @@ function isDOMElement(element) {
  */
 function getElementProps(element) {
   // props for react, attributes for preact
-  return element.props || /* istanbul ignore next (preact) */ element.attributes
+
+  /* istanbul ignore if */
+  if (isPreact) {
+    return element.attributes
+  }
+
+  return element.props
 }
 
 /**


### PR DESCRIPTION
fixes #540

Some snapshot sizes are bigger, some are smaller. This PR should remove some bytes in all the cases, gonna investigate this in a moment - I suspect those differences might be caused by newer versions of downshift's deps and not downshift itself, but cant be sure right now.

EDIT:// yeah, running the build on master with fresh deps updates the snapshot, so size regressions are not caused by this PR

@TrySound would it be possible to output additional snapshot sizes for the lib itself with all deps as external? Both numbers are valuable (with externals bundled in and without them)