### PR TITLE
add id props to DownshiftProps type

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -62,6 +62,10 @@ export interface DownshiftProps<Item> {
   selectedItem?: Item | null
   children?: ChildrenFunction<Item>
   id?: string
+  inputId?: string
+  labelId?: string
+  menuId?: string
+  getItemId?: (index?: number) => string
   environment?: Environment
   onOuterClick?: (stateAndHelpers: ControllerStateAndHelpers<Item>) => void
   onUserAction?: (


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**
The DownshiftProps typescript type does not include the following props: inputId, labelId, menuId, getItemId.  See issue #530 .  This PR adds the missing props.

<!-- Why are these changes necessary? -->
**Why**
To improve typescript support

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

After running `npm run setup`, but before making any changes to the repo, I noticed the .size-snapshot.json was changed.  The changes in this PR didn't affect the .size-snapshot.json file that is generated, so I didn't commit `.size-snapshot.json`.   Please let me know if you would like me to.
