### PR TITLE
Made `GetMenuPropsOptions` and `GetItemPropsOptions` more accurate

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -113,7 +113,8 @@ export interface GetLabelPropsOptions
 export interface GetToggleButtonPropsOptions
   extends React.HTMLProps<HTMLButtonElement> {}
 
-export interface GetMenuPropsOptions {
+export interface GetMenuPropsOptions
+  extends React.HTMLProps<HTMLElement> {
   refKey?: string
   ['aria-label']?: string
 }
@@ -122,7 +123,8 @@ export interface GetPropsCommonOptions {
   suppressRefError?: boolean
 }
 
-export interface GetItemPropsOptions<Item> extends Record<string, any> {
+export interface GetItemPropsOptions<Item>
+  extends React.HTMLProps<HTMLElement> {
   index?: number
   item: Item
 }


### PR DESCRIPTION
Made `GetMenuPropsOptions` and `GetItemPropsOptions` more accurate

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Made `GetMenuPropsOptions` and `GetItemPropsOptions` more accurate
<!-- Why are these changes necessary? -->

**Why**:

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
