### PR TITLE
fix: Remove Object.assign call for IE compatibility

### DIFF
--- a/src/set-a11y-status.js
+++ b/src/set-a11y-status.js
@@ -56,16 +56,15 @@ function getStatusDiv() {
   statusDiv.setAttribute('role', 'status')
   statusDiv.setAttribute('aria-live', 'assertive')
   statusDiv.setAttribute('aria-relevant', 'additions text')
-  Object.assign(statusDiv.style, {
-    border: '0',
-    clip: 'rect(0 0 0 0)',
-    height: '1px',
-    margin: '-1px',
-    overflow: 'hidden',
-    padding: '0',
-    position: 'absolute',
-    width: '1px',
-  })
+  statusDiv.style.border = '0'
+  statusDiv.style.clip = 'rect(0 0 0 0)'
+  statusDiv.style.height = '1px'
+  statusDiv.style.margin = '-1px'
+  statusDiv.style.overflow = 'hidden'
+  statusDiv.style.padding = '0'
+  statusDiv.style.position = 'absolute'
+  statusDiv.style.width = '1px'
+
   document.body.appendChild(statusDiv)
   return statusDiv
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Replaced the `Object.assign` call in `getStatusDiv()` with direct assignments to `statusDiv.style`

<!-- Why are these changes necessary? -->

**Why**: This code was throwing exceptions in IE11.
I noticed that it is the only usage of `Object.assign` in the codebase, so I don't think it justifies the need for a polyfill. For spreading object properties, Babel already seems to add its own `_extends` ponyfill.

<!-- How were these changes implemented? -->


<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
