### PR TITLE
types: Item can be null in onChange and onSelect

### DIFF
--- a/test/basic.test.tsx
+++ b/test/basic.test.tsx
@@ -15,7 +15,7 @@ export default class App extends React.Component<Props, State> {
     items: ['apple', 'orange', 'carrot'],
   }
 
-  onChange = (selectedItem: Item) => {
+  onChange = (selectedItem: Item | null) => {
     console.log('selectedItem', selectedItem)
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -38,11 +38,11 @@ export interface DownshiftProps<Item> {
   selectedItemChanged?: (prevItem: Item, item: Item) => boolean
   getA11yStatusMessage?: (options: A11yStatusMessageOptions<Item>) => string
   onChange?: (
-    selectedItem: Item,
+    selectedItem: Item | null,
     stateAndHelpers: ControllerStateAndHelpers<Item>,
   ) => void
   onSelect?: (
-    selectedItem: Item,
+    selectedItem: Item | null,
     stateAndHelpers: ControllerStateAndHelpers<Item>,
   ) => void
   onStateChange?: (


### PR DESCRIPTION
**What**:

I noticed that the item in `onChange` and `onSelect` handlers can be sometimes null. In TS strict mode Typescript usually warns about these situations but here I hit a runtime error.

Here's an example where the `item` is null in `onChange`: 

https://codesandbox.io/s/ywzpvv3jjz

Just select a fruit from the list and see `ordered-examples/01-basic-autocomplete`.


**Why**:

Typescript typings should reflect the real Javascript types closely as possible. 

**How**:

Item is now an union with null in `onChance` and `onSelect` which forces Typescript users to check for it in strict mode to avoid the runtime error.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

<strike>
The tests "kinda pass". I wasn't able to execute the test successfully even with a plain master branch without any of my changes.

From `npm run validate` I get 

```
[build-and-test] [react.cjs] /var/www/git/downshift/src/index.js → dist/downshift.cjs.js...
[test:cypress] events.js:183
[test:cypress]       throw er; // Unhandled 'error' event
[test:cypress]       ^
[test:cypress]
[test:cypress] Error: watch /var/www/git/downshift/doczrc.js ENOSPC
```

Also `npm run test:ts` complain about jquery types on the master branch but that's not related to the changes neither.
</strike>

Update: Weird. The tests pass on Travis 😃 	