### PR TITLE
Document stateChangeTypes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,12 +516,28 @@ There are a few props that expose changes to state
 For you to make the most of these APIs, it's important for you to understand
 why state is being changed. To accomplish this, there's a `type` property on the
 `changes` object you get. This `type` corresponds to a
-`Downshift.stateChangeTypes` property. If you want to see what change types
-are available, run this in your app:
+`Downshift.stateChangeTypes` property.
 
-```javascript
-console.log(Object.keys(Downshift.stateChangeTypes))
-```
+The list of all possible values this `type` property can take is as follows:
+
+  - `Downshift.stateChangeTypes.unknown`
+  - `Downshift.stateChangeTypes.mouseUp`
+  - `Downshift.stateChangeTypes.itemMouseEnter`
+  - `Downshift.stateChangeTypes.keyDownArrowUp`
+  - `Downshift.stateChangeTypes.keyDownArrowDown`
+  - `Downshift.stateChangeTypes.keyDownEscape`
+  - `Downshift.stateChangeTypes.keyDownEnter`
+  - `Downshift.stateChangeTypes.clickItem`
+  - `Downshift.stateChangeTypes.blurInput`
+  - `Downshift.stateChangeTypes.changeInput`
+  - `Downshift.stateChangeTypes.keyDownSpaceButton`
+  - `Downshift.stateChangeTypes.clickButton`
+  - `Downshift.stateChangeTypes.blurButton`
+  - `Downshift.stateChangeTypes.controlledPropUpdatedSelectedItem`
+  - `Downshift.stateChangeTypes.touchEnd`
+
+See [`stateReducer`](#statereducer) for a concrete example on how to use the
+`type` property.
 
 ## Control Props
 

--- a/README.md
+++ b/README.md
@@ -518,7 +518,9 @@ why state is being changed. To accomplish this, there's a `type` property on the
 `changes` object you get. This `type` corresponds to a
 `Downshift.stateChangeTypes` property.
 
-The list of all possible values this `type` property can take is as follows:
+The list of all possible values this `type` property can take is defined in
+[this file](https://github.com/paypal/downshift/blob/master/src/stateChangeTypes.js)
+and is as follows:
 
   - `Downshift.stateChangeTypes.unknown`
   - `Downshift.stateChangeTypes.mouseUp`


### PR DESCRIPTION
**What**: The goal is to fix #620.
**Why**: The documentation does not list the possible values for the `type` property.
**How**: Added missing documentation.
**Checklist**:
- [x] Ready to be merged
- [ ] Added myself to contributors table
