### PR TITLE
Accessibility status changes

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,54 +1,54 @@
 {
   "preact/dist/downshift.cjs.js": {
-    "bundled": 51893,
-    "minified": 22279,
-    "gzipped": 6334
+    "bundled": 52167,
+    "minified": 22171,
+    "gzipped": 6316
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 63416,
-    "minified": 21897,
-    "gzipped": 7054
+    "bundled": 62743,
+    "minified": 21507,
+    "gzipped": 6957
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 69878,
-    "minified": 23606,
-    "gzipped": 7821
+    "bundled": 66920,
+    "minified": 22681,
+    "gzipped": 7498
   },
   "dist/downshift.cjs.js": {
-    "bundled": 53324,
-    "minified": 23429,
-    "gzipped": 6530
+    "bundled": 53598,
+    "minified": 23321,
+    "gzipped": 6512
   },
   "dist/downshift.umd.js": {
-    "bundled": 108009,
-    "minified": 36671,
-    "gzipped": 11286
+    "bundled": 103748,
+    "minified": 35161,
+    "gzipped": 10912
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 51539,
-    "minified": 22003,
-    "gzipped": 6268,
+    "bundled": 51813,
+    "minified": 21895,
+    "gzipped": 6250,
     "treeshaked": {
       "rollup": {
-        "code": 16241,
+        "code": 16133,
         "import_statements": 336
       },
       "webpack": {
-        "code": 17507
+        "code": 17399
       }
     }
   },
   "dist/downshift.esm.js": {
-    "bundled": 52950,
-    "minified": 23138,
-    "gzipped": 6462,
+    "bundled": 53224,
+    "minified": 23030,
+    "gzipped": 6445,
     "treeshaked": {
       "rollup": {
-        "code": 16251,
+        "code": 16143,
         "import_statements": 354
       },
       "webpack": {
-        "code": 17550
+        "code": 17442
       }
     }
   },
@@ -58,8 +58,8 @@
     "gzipped": 9728
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 76138,
-    "minified": 27144,
-    "gzipped": 8471
+    "bundled": 74859,
+    "minified": 26572,
+    "gzipped": 8331
   }
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -5,50 +5,50 @@
     "gzipped": 6316
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 62743,
-    "minified": 21507,
-    "gzipped": 6957
+    "bundled": 62334,
+    "minified": 21623,
+    "gzipped": 6971
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 66920,
-    "minified": 22681,
-    "gzipped": 7498
+    "bundled": 66511,
+    "minified": 22797,
+    "gzipped": 7514
   },
   "dist/downshift.cjs.js": {
-    "bundled": 53598,
-    "minified": 23321,
-    "gzipped": 6512
+    "bundled": 53213,
+    "minified": 23437,
+    "gzipped": 6529
   },
   "dist/downshift.umd.js": {
-    "bundled": 103748,
-    "minified": 35161,
-    "gzipped": 10912
+    "bundled": 103339,
+    "minified": 35277,
+    "gzipped": 10927
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 51813,
-    "minified": 21895,
-    "gzipped": 6250,
+    "bundled": 51428,
+    "minified": 22011,
+    "gzipped": 6267,
     "treeshaked": {
       "rollup": {
-        "code": 16133,
+        "code": 16249,
         "import_statements": 336
       },
       "webpack": {
-        "code": 17399
+        "code": 17515
       }
     }
   },
   "dist/downshift.esm.js": {
-    "bundled": 53224,
-    "minified": 23030,
-    "gzipped": 6445,
+    "bundled": 52839,
+    "minified": 23146,
+    "gzipped": 6462,
     "treeshaked": {
       "rollup": {
-        "code": 16143,
+        "code": 16259,
         "import_statements": 354
       },
       "webpack": {
-        "code": 17442
+        "code": 17558
       }
     }
   },
@@ -58,8 +58,8 @@
     "gzipped": 9728
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 74859,
-    "minified": 26572,
-    "gzipped": 8331
+    "bundled": 74450,
+    "minified": 26688,
+    "gzipped": 8345
   }
 }

--- a/src/__tests__/__snapshots__/downshift.aria.js.snap
+++ b/src/__tests__/__snapshots__/downshift.aria.js.snap
@@ -37,7 +37,7 @@ exports[`basic snapshot 1`] = `
     role="listbox"
   >
     <li
-      aria-selected="true"
+      aria-selected="false"
       data-testid="item-0"
       id="downshift-0-item-0"
       role="option"

--- a/src/__tests__/__snapshots__/set-a11y-status.js.snap
+++ b/src/__tests__/__snapshots__/set-a11y-status.js.snap
@@ -2,7 +2,7 @@
 
 exports[`clears statuses when a change appears 1`] = `
 <div
-  aria-live="assertive"
+  aria-live="polite"
   aria-relevant="additions text"
   id="a11y-status-message"
   role="status"
@@ -18,7 +18,7 @@ exports[`clears statuses when a change appears 1`] = `
 
 exports[`does add anything for an empty string 1`] = `
 <div
-  aria-live="assertive"
+  aria-live="polite"
   aria-relevant="additions text"
   id="a11y-status-message"
   role="status"
@@ -28,7 +28,7 @@ exports[`does add anything for an empty string 1`] = `
 
 exports[`escapes HTML 1`] = `
 <div
-  aria-live="assertive"
+  aria-live="polite"
   aria-relevant="additions text"
   id="a11y-status-message"
   role="status"
@@ -44,7 +44,7 @@ exports[`escapes HTML 1`] = `
 
 exports[`repeat statuses get appended as children 1`] = `
 <div
-  aria-live="assertive"
+  aria-live="polite"
   aria-relevant="additions text"
   id="a11y-status-message"
   role="status"
@@ -70,7 +70,7 @@ exports[`repeat statuses get appended as children 1`] = `
 
 exports[`sets the status 1`] = `
 <div
-  aria-live="assertive"
+  aria-live="polite"
   aria-relevant="additions text"
   id="a11y-status-message"
   role="status"

--- a/src/__tests__/utils.get-a11y-status-message.js
+++ b/src/__tests__/utils.get-a11y-status-message.js
@@ -23,14 +23,15 @@ const tests = [
       isOpen: true,
       resultCount: 0,
     },
-    output: 'No results.',
+    output: 'No results are available.',
   },
   {
     input: {
       isOpen: true,
       resultCount: 10,
     },
-    output: '10 results are available, use up and down arrow keys to navigate.',
+    output:
+      '10 results are available, use up and down arrow keys to navigate. Press Enter key to select.',
   },
   {
     input: {
@@ -38,7 +39,8 @@ const tests = [
       resultCount: 9,
       previousResultCount: 12,
     },
-    output: '9 results are available, use up and down arrow keys to navigate.',
+    output:
+      '9 results are available, use up and down arrow keys to navigate. Press Enter key to select.',
   },
   {
     input: {
@@ -47,14 +49,16 @@ const tests = [
       previousResultCount: 20,
       highlightedItem: 'Oranges',
     },
-    output: '8 results are available, use up and down arrow keys to navigate.',
+    output:
+      '8 results are available, use up and down arrow keys to navigate. Press Enter key to select.',
   },
   {
     input: {
       isOpen: true,
       resultCount: 1,
     },
-    output: '1 result is available, use up and down arrow keys to navigate.',
+    output:
+      '1 result is available, use up and down arrow keys to navigate. Press Enter key to select.',
   },
   {
     input: {
@@ -65,7 +69,7 @@ const tests = [
       selectedItem: 'Raspberries',
       highlightedItem: 'Raspberries',
     },
-    output: 'Raspberries',
+    output: '',
   },
 ]
 

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -952,11 +952,13 @@ class Downshift extends Component {
 
   updateStatus = debounce(() => {
     const state = this.getState()
+    const item = this.items[state.highlightedIndex]
     const resultCount = this.getItemCount()
     const status = this.props.getA11yStatusMessage({
       itemToString: this.props.itemToString,
       previousResultCount: this.previousResultCount,
       resultCount,
+      highlightedItem: item,
       ...state,
     })
     this.previousResultCount = resultCount

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -901,7 +901,7 @@ class Downshift extends Component {
     return {
       id: this.getItemId(index),
       role: 'option',
-      'aria-selected': this.getState().selectedItem === item,
+      'aria-selected': this.getState().highlightedIndex === index,
       ...eventHandlers,
       ...rest,
     }
@@ -952,13 +952,11 @@ class Downshift extends Component {
 
   updateStatus = debounce(() => {
     const state = this.getState()
-    const item = this.items[state.highlightedIndex]
     const resultCount = this.getItemCount()
     const status = this.props.getA11yStatusMessage({
       itemToString: this.props.itemToString,
       previousResultCount: this.previousResultCount,
       resultCount,
-      highlightedItem: item,
       ...state,
     })
     this.previousResultCount = resultCount

--- a/src/set-a11y-status.js
+++ b/src/set-a11y-status.js
@@ -54,7 +54,7 @@ function getStatusDiv() {
   statusDiv = document.createElement('div')
   statusDiv.setAttribute('id', 'a11y-status-message')
   statusDiv.setAttribute('role', 'status')
-  statusDiv.setAttribute('aria-live', 'assertive')
+  statusDiv.setAttribute('aria-live', 'polite')
   statusDiv.setAttribute('aria-relevant', 'additions text')
   Object.assign(statusDiv.style, {
     border: '0',

--- a/src/utils.js
+++ b/src/utils.js
@@ -144,28 +144,23 @@ function resetIdCounter() {
  */
 function getA11yStatusMessage({
   isOpen,
-  highlightedItem,
   selectedItem,
   resultCount,
   previousResultCount,
   itemToString,
 }) {
   if (!isOpen) {
-    if (selectedItem) {
-      return itemToString(selectedItem)
-    } else {
-      return ''
-    }
+    return selectedItem ? itemToString(selectedItem) : ''
   }
-  const resultCountChanged = resultCount !== previousResultCount
   if (!resultCount) {
-    return 'No results.'
-  } else if (!highlightedItem || resultCountChanged) {
-    return `${resultCount} ${
-      resultCount === 1 ? 'result is' : 'results are'
-    } available, use up and down arrow keys to navigate.`
+    return 'No results are available.'
   }
-  return itemToString(highlightedItem)
+  if (resultCount !== previousResultCount) {
+    return `${resultCount} result${
+      resultCount === 1 ? ' is' : 's are'
+    } available, use up and down arrow keys to navigate. Press Enter key to select.`
+  }
+  return ''
 }
 
 /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -90,6 +90,7 @@ export interface A11yStatusMessageOptions<Item> {
   itemToString: (item: Item) => string
   previousResultCount: number
   resultCount: number
+  highlightedItem: Item
   selectedItem: Item
 }
 


### PR DESCRIPTION
Mainly addressing https://github.com/paypal/downshift/issues/621 but also the process overall. I had a hunch about what caused Safari not to read the options, and it was the fact that we are using aria-selected wrong (true, many use it this way).

According to Aria, aria-selected marks the currently highlighted option in the list, not the actual selected item (or items if we have multiple choice). Came across this [github issue](https://github.com/select2/select2/issues/4349) and also the aria spec [here](https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html), specifically at the Listbox Popup section.

Changes I made, explained.

1. When user navigates through the options, don't update the aria-live message anymore. Will leave the default screen reader behaviour in reading (Black, 1 of 6).
2. Will fix Safari by adding `aria-selected="true"` to the highlighter element. Bad news is that it will break the implementations that use it incorrectly. Good news is that we can add the highlight style using that class, rather than using the style attribute (not sure if an improvement, but saw this being done many times).
3. Will narrate how many options exist any time their number change. I think it makes sense that the user should be notified about this. Use case: going through the options (so having a highlighted item) and also changing the query string in the input (so the number of options may change).
4. Making these announcements polite. It is not a warning / error message, like 'Form not submitted/Problem with connection', we should not interrupt. For instance, navigating to the dropdown, pressing Down will first narrate the first option, and then will narrate the number of options.
5. Some minor changes related to the actual message. I got these suggestions from the accessibility team I am working with, I think they are a nice touch.
6. Added `highlightedItem` to the TS types `A11yStatusMessageOptions<Item>`, as it was missing, and in `downshift.js` that method is also called with the `highlightedItem`.
7. Changed the unit tests to match new behaviour.
8. Nit: `const status = this.props.getA11yStatusMessage({` was called with highlighted item twice, once with the one from array, then was overridden with the one from state. I removed the first, please take a look and see if it correct.