### PR TITLE
Stop handled key events propagating

### DIFF
--- a/src/__tests__/downshift.get-button-props.js
+++ b/src/__tests__/downshift.get-button-props.js
@@ -90,6 +90,26 @@ test(`getToggleButtonProps doesn't include event handlers when disabled is passe
   }
 })
 
+test('stops key events that downshift has handled from propagating', () => {
+  const keyDownSpy = jest.fn()
+  const {container} = render(
+    <div onKeyDown={keyDownSpy}>
+      <Downshift isOpen highlightedIndex={1}>
+        {({getToggleButtonProps}) => <button {...getToggleButtonProps()} />}
+      </Downshift>
+    </div>,
+  )
+
+  const button = container.querySelector('button')
+
+  fireEvent.keyDown(button, {key: 'ArrowDown'})
+  fireEvent.keyDown(button, {key: 'ArrowUp'})
+  fireEvent.keyDown(button, {key: 'Enter'})
+  fireEvent.keyDown(button, {key: 'Escape'})
+
+  expect(keyDownSpy).toHaveBeenCalledTimes(0)
+})
+
 describe('Expect timer to trigger on process.env.NODE_ENV !== test value', () => {
   const originalEnv = process.env.NODE_ENV
 

--- a/src/__tests__/downshift.get-input-props.js
+++ b/src/__tests__/downshift.get-input-props.js
@@ -317,6 +317,26 @@ test(`getInputProps doesn't include event handlers when disabled is passed (for 
   }
 })
 
+test('stops events that downshift has handled from propagating', () => {
+  const keyDownSpy = jest.fn()
+  const {container} = render(
+    <div onKeyDown={keyDownSpy}>
+      <Downshift isOpen highlightedIndex={1}>
+        {({getInputProps}) => <input {...getInputProps()} />}
+      </Downshift>
+    </div>,
+  )
+
+  const input = container.querySelector('input')
+
+  fireEvent.keyDown(input, {key: 'ArrowDown'})
+  fireEvent.keyDown(input, {key: 'ArrowUp'})
+  fireEvent.keyDown(input, {key: 'Enter'})
+  fireEvent.keyDown(input, {key: 'Escape'})
+
+  expect(keyDownSpy).toHaveBeenCalledTimes(0)
+})
+
 function setupDownshiftWithState() {
   const items = ['animal', 'bug', 'cat']
   const utils = renderDownshift({items})

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -554,6 +554,7 @@ class Downshift extends Component {
   keyDownHandlers = {
     ArrowDown(event) {
       event.preventDefault()
+      event.stopPropagation()
       const amount = event.shiftKey ? 5 : 1
       this.moveHighlightedIndex(amount, {
         type: stateChangeTypes.keyDownArrowDown,
@@ -562,6 +563,7 @@ class Downshift extends Component {
 
     ArrowUp(event) {
       event.preventDefault()
+      event.stopPropagation()
       const amount = event.shiftKey ? -5 : -1
       this.moveHighlightedIndex(amount, {
         type: stateChangeTypes.keyDownArrowUp,
@@ -572,6 +574,7 @@ class Downshift extends Component {
       const {isOpen, highlightedIndex} = this.getState()
       if (isOpen && highlightedIndex != null) {
         event.preventDefault()
+        event.stopPropagation()
         const item = this.items[highlightedIndex]
         const itemNode = this.getItemNodeFromIndex(highlightedIndex)
         if (item == null || (itemNode && itemNode.hasAttribute('disabled'))) {
@@ -585,6 +588,7 @@ class Downshift extends Component {
 
     Escape(event) {
       event.preventDefault()
+      event.stopPropagation()
       this.reset({type: stateChangeTypes.keyDownEscape})
     },
   }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Stop the propagation of keydown events that have been handled by downshift

<!-- Why are these changes necessary? -->

**Why**: If I am using downshift inside a component that is also handling key events then it shouldn't be receiving them if downshift has already taken action

<!-- How were these changes implemented? -->

**How**: using `event.stopPropagation()`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation "N/A" - I think there's nothing to add to the documentation about this, the user can still disable this behaviour (as they could before) by setting `event.preventDownshiftDefault`, so I don't think there needs to be a new addition to the dos?
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table - the `add-contributors` script failed on my windows machine
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

This fixes issue #630 
