### PR TITLE
Fix ie tab issue

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1003,6 +1003,15 @@
         "bug",
         "code"
       ]
+    },
+    {
+      "login": "mdugue",
+      "name": "Manuel Dugué",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/894149?v=4",
+      "profile": "http://manueldugue.de",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,54 +1,54 @@
 {
   "preact/dist/downshift.cjs.js": {
-    "bundled": 51689,
-    "minified": 22142,
-    "gzipped": 6302
+    "bundled": 51893,
+    "minified": 22279,
+    "gzipped": 6334
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 62241,
-    "minified": 21478,
-    "gzipped": 6945
+    "bundled": 63416,
+    "minified": 21897,
+    "gzipped": 7054
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 66418,
-    "minified": 22652,
-    "gzipped": 7486
+    "bundled": 69878,
+    "minified": 23606,
+    "gzipped": 7821
   },
   "dist/downshift.cjs.js": {
-    "bundled": 53120,
-    "minified": 23292,
-    "gzipped": 6499
+    "bundled": 53324,
+    "minified": 23429,
+    "gzipped": 6530
   },
   "dist/downshift.umd.js": {
-    "bundled": 103246,
-    "minified": 35132,
-    "gzipped": 10900
+    "bundled": 108009,
+    "minified": 36671,
+    "gzipped": 11286
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 51335,
-    "minified": 21866,
-    "gzipped": 6236,
+    "bundled": 51539,
+    "minified": 22003,
+    "gzipped": 6268,
     "treeshaked": {
       "rollup": {
-        "code": 16104,
+        "code": 16241,
         "import_statements": 336
       },
       "webpack": {
-        "code": 17369
+        "code": 17507
       }
     }
   },
   "dist/downshift.esm.js": {
-    "bundled": 52746,
-    "minified": 23001,
-    "gzipped": 6431,
+    "bundled": 52950,
+    "minified": 23138,
+    "gzipped": 6462,
     "treeshaked": {
       "rollup": {
-        "code": 16114,
+        "code": 16251,
         "import_statements": 354
       },
       "webpack": {
-        "code": 17412
+        "code": 17550
       }
     }
   },
@@ -58,8 +58,8 @@
     "gzipped": 9728
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 74357,
-    "minified": 26543,
-    "gzipped": 8321
+    "bundled": 76138,
+    "minified": 27144,
+    "gzipped": 8471
   }
 }

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ autocomplete/dropdown/select/combobox components</p>
 [![downloads][downloads-badge]][npmcharts] [![version][version-badge]][package]
 [![MIT License][license-badge]][license]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-102-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-103-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs] [![Chat][chat-badge]][chat]
 [![Code of Conduct][coc-badge]][coc]
 [![Join the community on Spectrum][spectrum-badge]][spectrum]
@@ -522,21 +522,21 @@ The list of all possible values this `type` property can take is defined in
 [this file](https://github.com/paypal/downshift/blob/master/src/stateChangeTypes.js)
 and is as follows:
 
-  - `Downshift.stateChangeTypes.unknown`
-  - `Downshift.stateChangeTypes.mouseUp`
-  - `Downshift.stateChangeTypes.itemMouseEnter`
-  - `Downshift.stateChangeTypes.keyDownArrowUp`
-  - `Downshift.stateChangeTypes.keyDownArrowDown`
-  - `Downshift.stateChangeTypes.keyDownEscape`
-  - `Downshift.stateChangeTypes.keyDownEnter`
-  - `Downshift.stateChangeTypes.clickItem`
-  - `Downshift.stateChangeTypes.blurInput`
-  - `Downshift.stateChangeTypes.changeInput`
-  - `Downshift.stateChangeTypes.keyDownSpaceButton`
-  - `Downshift.stateChangeTypes.clickButton`
-  - `Downshift.stateChangeTypes.blurButton`
-  - `Downshift.stateChangeTypes.controlledPropUpdatedSelectedItem`
-  - `Downshift.stateChangeTypes.touchEnd`
+- `Downshift.stateChangeTypes.unknown`
+- `Downshift.stateChangeTypes.mouseUp`
+- `Downshift.stateChangeTypes.itemMouseEnter`
+- `Downshift.stateChangeTypes.keyDownArrowUp`
+- `Downshift.stateChangeTypes.keyDownArrowDown`
+- `Downshift.stateChangeTypes.keyDownEscape`
+- `Downshift.stateChangeTypes.keyDownEnter`
+- `Downshift.stateChangeTypes.clickItem`
+- `Downshift.stateChangeTypes.blurInput`
+- `Downshift.stateChangeTypes.changeInput`
+- `Downshift.stateChangeTypes.keyDownSpaceButton`
+- `Downshift.stateChangeTypes.clickButton`
+- `Downshift.stateChangeTypes.blurButton`
+- `Downshift.stateChangeTypes.controlledPropUpdatedSelectedItem`
+- `Downshift.stateChangeTypes.touchEnd`
 
 See [`stateReducer`](#statereducer) for a concrete example on how to use the
 `type` property.
@@ -1096,7 +1096,7 @@ Thanks goes to these people ([emoji key][emojis]):
 | [<img src="https://avatars3.githubusercontent.com/u/5456216?v=4" width="100px;"/><br /><sub><b>Cameron Edwards</b></sub>](http://cameronpedwards.com)<br />[💻](https://github.com/paypal/downshift/commits?author=cameronprattedwards "Code") [⚠️](https://github.com/paypal/downshift/commits?author=cameronprattedwards "Tests") | [<img src="https://avatars2.githubusercontent.com/u/179534?v=4" width="100px;"/><br /><sub><b>stereobooster</b></sub>](https://github.com/stereobooster)<br />[💻](https://github.com/paypal/downshift/commits?author=stereobooster "Code") [⚠️](https://github.com/paypal/downshift/commits?author=stereobooster "Tests") | [<img src="https://avatars0.githubusercontent.com/u/934879?v=4" width="100px;"/><br /><sub><b>Trevor Pierce</b></sub>](https://github.com/1Copenut)<br />[👀](#review-1Copenut "Reviewed Pull Requests") | [<img src="https://avatars1.githubusercontent.com/u/1334982?v=4" width="100px;"/><br /><sub><b>Xuefei Li</b></sub>](http://xuefei-frank.com)<br />[💻](https://github.com/paypal/downshift/commits?author=franklixuefei "Code") | [<img src="https://avatars0.githubusercontent.com/u/7252803?v=4" width="100px;"/><br /><sub><b>Alfred Ringstad</b></sub>](https://hyperlab.se)<br />[💻](https://github.com/paypal/downshift/commits?author=alfredringstad "Code") | [<img src="https://avatars0.githubusercontent.com/u/6895497?v=4" width="100px;"/><br /><sub><b>D[oa]vid Weisz</b></sub>](https://github.com/dovidweisz)<br />[💻](https://github.com/paypal/downshift/commits?author=dovidweisz "Code") | [<img src="https://avatars0.githubusercontent.com/u/19773?v=4" width="100px;"/><br /><sub><b>Royston Shufflebotham</b></sub>](https://github.com/RoystonS)<br />[🐛](https://github.com/paypal/downshift/issues?q=author%3ARoystonS "Bug reports") [💻](https://github.com/paypal/downshift/commits?author=RoystonS "Code") |
 | [<img src="https://avatars3.githubusercontent.com/u/6643991?v=4" width="100px;"/><br /><sub><b>Michaël De Boey</b></sub>](http://michaeldeboey.be)<br />[💻](https://github.com/paypal/downshift/commits?author=MichaelDeBoey "Code") | [<img src="https://avatars3.githubusercontent.com/u/4412771?v=4" width="100px;"/><br /><sub><b>Henry</b></sub>](https://github.com/EricHenry)<br />[💻](https://github.com/paypal/downshift/commits?author=EricHenry "Code") | [<img src="https://avatars3.githubusercontent.com/u/2180127?v=4" width="100px;"/><br /><sub><b>Andrew Walton</b></sub>](http://www.greenarrow.me)<br />[🐛](https://github.com/paypal/downshift/issues?q=author%3Agreen-arrow "Bug reports") [💻](https://github.com/paypal/downshift/commits?author=green-arrow "Code") [⚠️](https://github.com/paypal/downshift/commits?author=green-arrow "Tests") | [<img src="https://avatars0.githubusercontent.com/u/13774309?v=4" width="100px;"/><br /><sub><b>Arthur Denner</b></sub>](https://github.com/arthurdenner)<br />[💻](https://github.com/paypal/downshift/commits?author=arthurdenner "Code") | [<img src="https://avatars2.githubusercontent.com/u/81981?v=4" width="100px;"/><br /><sub><b>Cody Olsen</b></sub>](http://twitter.com/stipsan)<br />[💻](https://github.com/paypal/downshift/commits?author=stipsan "Code") | [<img src="https://avatars0.githubusercontent.com/u/5084492?v=4" width="100px;"/><br /><sub><b>Thomas Ladd</b></sub>](https://github.com/TLadd)<br />[💻](https://github.com/paypal/downshift/commits?author=TLadd "Code") | [<img src="https://avatars3.githubusercontent.com/u/34634369?v=4" width="100px;"/><br /><sub><b>lixualinta</b></sub>](https://github.com/lixualinta)<br />[💻](https://github.com/paypal/downshift/commits?author=lixualinta "Code") |
 | [<img src="https://avatars2.githubusercontent.com/u/2118956?v=4" width="100px;"/><br /><sub><b>Jacob Cofman</b></sub>](https://twitter.com/JCofman)<br />[💻](https://github.com/paypal/downshift/commits?author=JCofman "Code") | [<img src="https://avatars3.githubusercontent.com/u/19275184?v=4" width="100px;"/><br /><sub><b>Joshua Freedman</b></sub>](https://github.com/jf248)<br />[💻](https://github.com/paypal/downshift/commits?author=jf248 "Code") | [<img src="https://avatars1.githubusercontent.com/u/24494020?v=4" width="100px;"/><br /><sub><b>Amy</b></sub>](https://github.com/AmyScript)<br />[💡](#example-AmyScript "Examples") | [<img src="https://avatars1.githubusercontent.com/u/9063669?v=4" width="100px;"/><br /><sub><b>Rogin Farrer</b></sub>](http://twitter.com/roginfarrer)<br />[💻](https://github.com/paypal/downshift/commits?author=roginfarrer "Code") | [<img src="https://avatars3.githubusercontent.com/u/871583" width="100px;"/><br /><sub><b>Dmitrii Kanatnikov</b></sub>](https://github.com/rifler)<br />[💻](https://github.com/paypal/downshift/commits?author=rifler "Code") | [<img src="https://avatars2.githubusercontent.com/u/346300?v=4" width="100px;"/><br /><sub><b>Dallon Feldner</b></sub>](https://github.com/dallonf)<br />[🐛](https://github.com/paypal/downshift/issues?q=author%3Adallonf "Bug reports") [💻](https://github.com/paypal/downshift/commits?author=dallonf "Code") | [<img src="https://avatars2.githubusercontent.com/u/10165959?v=4" width="100px;"/><br /><sub><b>Samuel Fuller Thomas</b></sub>](https://samuelfullerthomas.com)<br />[💻](https://github.com/paypal/downshift/commits?author=samuelfullerthomas "Code") |
-| [<img src="https://avatars1.githubusercontent.com/u/2430381?v=4" width="100px;"/><br /><sub><b>Ryan Castner</b></sub>](http://audiolion.github.io)<br />[💻](https://github.com/paypal/downshift/commits?author=audiolion "Code") | [<img src="https://avatars2.githubusercontent.com/u/11275392?v=4" width="100px;"/><br /><sub><b>Silviu Alexandru Avram</b></sub>](https://github.com/silviuavram)<br />[🐛](https://github.com/paypal/downshift/issues?q=author%3Asilviuavram "Bug reports") [💻](https://github.com/paypal/downshift/commits?author=silviuavram "Code") [⚠️](https://github.com/paypal/downshift/commits?author=silviuavram "Tests") | [<img src="https://avatars1.githubusercontent.com/u/15676655?v=4" width="100px;"/><br /><sub><b>Anton Volkov</b></sub>](https://github.com/akronb)<br />[💻](https://github.com/paypal/downshift/commits?author=akronb "Code") [⚠️](https://github.com/paypal/downshift/commits?author=akronb "Tests") | [<img src="https://avatars3.githubusercontent.com/u/513363?v=4" width="100px;"/><br /><sub><b>Keegan Street</b></sub>](http://keegan.st)<br />[🐛](https://github.com/paypal/downshift/issues?q=author%3Akeeganstreet "Bug reports") [💻](https://github.com/paypal/downshift/commits?author=keeganstreet "Code") |
+| [<img src="https://avatars1.githubusercontent.com/u/2430381?v=4" width="100px;"/><br /><sub><b>Ryan Castner</b></sub>](http://audiolion.github.io)<br />[💻](https://github.com/paypal/downshift/commits?author=audiolion "Code") | [<img src="https://avatars2.githubusercontent.com/u/11275392?v=4" width="100px;"/><br /><sub><b>Silviu Alexandru Avram</b></sub>](https://github.com/silviuavram)<br />[🐛](https://github.com/paypal/downshift/issues?q=author%3Asilviuavram "Bug reports") [💻](https://github.com/paypal/downshift/commits?author=silviuavram "Code") [⚠️](https://github.com/paypal/downshift/commits?author=silviuavram "Tests") | [<img src="https://avatars1.githubusercontent.com/u/15676655?v=4" width="100px;"/><br /><sub><b>Anton Volkov</b></sub>](https://github.com/akronb)<br />[💻](https://github.com/paypal/downshift/commits?author=akronb "Code") [⚠️](https://github.com/paypal/downshift/commits?author=akronb "Tests") | [<img src="https://avatars3.githubusercontent.com/u/513363?v=4" width="100px;"/><br /><sub><b>Keegan Street</b></sub>](http://keegan.st)<br />[🐛](https://github.com/paypal/downshift/issues?q=author%3Akeeganstreet "Bug reports") [💻](https://github.com/paypal/downshift/commits?author=keeganstreet "Code") | [<img src="https://avatars1.githubusercontent.com/u/894149?v=4" width="100px;"/><br /><sub><b>Manuel Dugué</b></sub>](http://manueldugue.de)<br />[💻](https://github.com/paypal/downshift/commits?author=mdugue "Code") |
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -796,6 +796,7 @@ class Downshift extends Component {
     this.internalSetTimeout(() => {
       const downshiftButtonIsActive =
         this.props.environment.document &&
+        !!this.props.environment.document.activeElement.dataset &&
         this.props.environment.document.activeElement.dataset.toggle &&
         (this._rootNode &&
           this._rootNode.contains(


### PR DESCRIPTION
**What**:
neither a bug nor really a feature. Rather a graceful degradation improvement

**Why**:

as discussed in [https://github.com/paypal/downshift/issues/409](https://github.com/paypal/downshift/issues/409) there is an issue with Internet Explorer and SVG DOM elements. IE automatically sets `svg` elements that are next to input fields as `document.activeElement` upon pressing tab key. As IE does not support `dataset`s on SVG files, the current callback crashes.

While this issue does not seem to cause any functional problems it causes noise on the console and crash reporters.

**How**:

added an extra check if `dataset` property exists before using its keys.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

It would have been interesting to add an extra test, but IMHO this would only have been possible via complex DOM mocks or with seleniumm, which felt disproportionately. Please point me to related resources if I'm wrong.

**Reproduction**

Current **docz** approach is not working in Internet Explorer, so you won't be able to reproduce it that way. What I did was using downshift via `npm link` in some dummy project.