### PR TITLE
[TypeScript] Fixed type for "GetInputPropsOptions"

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -107,7 +107,7 @@ export interface GetRootPropsOptions {
 }
 
 export interface GetInputPropsOptions
-  extends React.HTMLProps<HTMLInputElement> {
+  extends React.HTMLProps<HTMLInputElement | HTMLTextAreaElement> {
   disabled?: boolean
 }
 


### PR DESCRIPTION
According to the latest `react` types, we should also allow `HTMLTextAreaElement` as part of the props for `GetInputPropsOptions`

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Typescript type fix.
<!-- Why are these changes necessary? -->

**Why**:
to make the type more accurate and prevent broken builds.
<!-- How were these changes implemented? -->

**How**:
I added `HTMLTextAreaElement` as part of the props to `GetInputPropsOptions`, according to the latest `react` type def.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
