### PR TITLE
(revert) [TypeScript] Fixed type for "GetInputPropsOptions"

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -108,7 +108,7 @@ export interface GetRootPropsOptions {
 }
 
 export interface GetInputPropsOptions
-  extends React.HTMLProps<HTMLInputElement | HTMLTextAreaElement> {
+  extends React.HTMLProps<HTMLInputElement> {
   disabled?: boolean
 }
 


### PR DESCRIPTION
Revert #639 
I decided to revert this change for the following reasons:
1. For now, downshift is not designed for textareas, so it doesn't make sense to account for the props that a textarea has in typings, which adds to the complexity of the type definitions.
2. this will no longer work (typescript compiler will throw):
```jsx
<input {...getInputProps(...)} />
```
because the returned type `React.HTMLProps<HTMLInputElement | HTMLTextAreaElement>` cannot be assigned to `React.HTMLProps<HTMLInputElement>`

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
