### PR TITLE
fix(scrollIntoView): use menuNode for boundary

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -2,7 +2,7 @@
   "preact/dist/downshift.cjs.js": {
     "bundled": 51792,
     "minified": 22290,
-    "gzipped": 6338
+    "gzipped": 6337
   },
   "preact/dist/downshift.umd.min.js": {
     "bundled": 64448,
@@ -17,12 +17,12 @@
   "dist/downshift.cjs.js": {
     "bundled": 53223,
     "minified": 23440,
-    "gzipped": 6534
+    "gzipped": 6533
   },
   "dist/downshift.umd.js": {
     "bundled": 105230,
     "minified": 35594,
-    "gzipped": 11027
+    "gzipped": 11025
   },
   "preact/dist/downshift.esm.js": {
     "bundled": 51438,
@@ -60,6 +60,6 @@
   "preact/dist/downshift.umd.js": {
     "bundled": 77156,
     "minified": 27099,
-    "gzipped": 8426
+    "gzipped": 8425
   }
 }

--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ This callback will only be called if `isOpen` is `true`.
 
 ### scrollIntoView
 
-> `function(node: HTMLElement, rootNode: HTMLElement)` | defaults to internal
+> `function(node: HTMLElement, menuNode: HTMLElement)` | defaults to internal
 > implementation
 
 This allows you to customize how the scrolling works when the highlighted index

--- a/src/__tests__/downshift.lifecycle.js
+++ b/src/__tests__/downshift.lifecycle.js
@@ -1,6 +1,6 @@
-import 'react-testing-library/cleanup-after-each'
 import React from 'react'
-import {render, fireEvent} from 'react-testing-library'
+import {fireEvent, render} from 'react-testing-library'
+import 'react-testing-library/cleanup-after-each'
 import Downshift from '../'
 import setA11yStatus from '../set-a11y-status'
 import * as utils from '../utils'
@@ -225,11 +225,13 @@ test('controlled highlighted index change scrolls the item into view', () => {
   // assuming that the test suite for utils.scrollIntoView will ensure
   // this functionality doesn't break.
   const oneHundredItems = Array.from({length: 100})
-  const renderFn = jest.fn(({getItemProps}) => (
-    <div data-testid="root">
-      {oneHundredItems.map((x, i) => (
-        <div key={i} {...getItemProps({item: i})} data-testid={`item-${i}`} />
-      ))}
+  const renderFn = jest.fn(({getItemProps, getMenuProps}) => (
+    <div>
+      <div data-testid="menu" {...getMenuProps()}>
+        {oneHundredItems.map((x, i) => (
+          <div key={i} {...getItemProps({item: i})} data-testid={`item-${i}`} />
+        ))}
+      </div>
     </div>
   ))
   const {container, updateProps, queryByTestId} = setup({
@@ -242,10 +244,10 @@ test('controlled highlighted index change scrolls the item into view', () => {
   expect(renderFn).toHaveBeenCalledTimes(1)
 
   expect(utils.scrollIntoView).toHaveBeenCalledTimes(1)
-  const rootDiv = queryByTestId('root')
+  const menuDiv = queryByTestId('menu')
   expect(utils.scrollIntoView).toHaveBeenCalledWith(
     queryByTestId('item-75'),
-    rootDiv,
+    menuDiv,
   )
 })
 

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -1,28 +1,28 @@
 /* eslint camelcase:0 */
 
-import React, {Component} from 'react'
 import PropTypes from 'prop-types'
+import React, {Component} from 'react'
 import {isForwardRef} from 'react-is'
 import {isPreact, isReactNative} from './is.macro'
 import setA11yStatus from './set-a11y-status'
 import * as stateChangeTypes from './stateChangeTypes'
 import {
-  cbToCb,
   callAll,
   callAllEventHandlers,
+  cbToCb,
   debounce,
-  scrollIntoView,
   generateId,
   getA11yStatusMessage,
-  unwrapArray,
+  getElementProps,
   isDOMElement,
   isOrContainsNode,
-  getElementProps,
-  noop,
-  requiredProp,
-  pickState,
   isPlainObject,
+  noop,
   normalizeArrowKey,
+  pickState,
+  requiredProp,
+  scrollIntoView,
+  unwrapArray,
 } from './utils'
 
 class Downshift extends Component {
@@ -254,7 +254,7 @@ class Downshift extends Component {
     /* istanbul ignore else (react-native) */
     if (!isReactNative) {
       const node = this.getItemNodeFromIndex(this.getState().highlightedIndex)
-      this.props.scrollIntoView(node, this._rootNode)
+      this.props.scrollIntoView(node, this._menuNode)
     }
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -20,15 +20,15 @@ function noop() {}
 /**
  * Scroll node into view if necessary
  * @param {HTMLElement} node the element that should scroll into view
- * @param {HTMLElement} rootNode the root element of the component
+ * @param {HTMLElement} menuNode the menu element of the component
  */
-function scrollIntoView(node, rootNode) {
+function scrollIntoView(node, menuNode) {
   if (node === null) {
     return
   }
 
   const actions = computeScrollIntoView(node, {
-    boundary: rootNode,
+    boundary: menuNode,
     block: 'nearest',
     scrollMode: 'if-needed',
   })


### PR DESCRIPTION
**What**: Use `menuNode` instead of `rootNode` as scrolling boundary.

**Why**: Closes #638

**How**: By changing the `scrollIntoView` callsite and updating docs and tests to refer to `menuNode`.

**Checklist**:

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
- [ ] Added myself to contributors table  N/A

Somehow this change gzips better and reduces bundlesize by a whopping *1 byte* 🎉 

##### Edit
Looks like my VS Code reorganized the imports ordering, I didn't intend to do that but I guess it doesn't hurt anyone 😅 