### PR TITLE
Handle End and Home Keys in list navigation

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,65 +1,60 @@
 {
+  "dist/downshift.cjs.js": {
+    "bundled": 54264,
+    "minified": 24037,
+    "gzipped": 6628
+  },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 51792,
-    "minified": 22290,
-    "gzipped": 6337
+    "bundled": 52833,
+    "minified": 22887,
+    "gzipped": 6433
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 64448,
-    "minified": 21905,
-    "gzipped": 7058
+    "bundled": 63298,
+    "minified": 22029,
+    "gzipped": 7062
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 68904,
-    "minified": 23079,
-    "gzipped": 7602
+    "bundled": 67475,
+    "minified": 23203,
+    "gzipped": 7603
   },
-  "dist/downshift.cjs.js": {
-    "bundled": 53223,
-    "minified": 23440,
-    "gzipped": 6533
+  "preact/dist/downshift.umd.js": {
+    "bundled": 75473,
+    "minified": 27153,
+    "gzipped": 8435
   },
   "dist/downshift.umd.js": {
-    "bundled": 105230,
-    "minified": 35594,
-    "gzipped": 11025
-  },
-  "preact/dist/downshift.esm.js": {
-    "bundled": 51438,
-    "minified": 22014,
-    "gzipped": 6270,
-    "treeshaked": {
-      "rollup": {
-        "code": 16252,
-        "import_statements": 336
-      },
-      "webpack": {
-        "code": 17518
-      }
-    }
+    "bundled": 104362,
+    "minified": 35748,
+    "gzipped": 11020
   },
   "dist/downshift.esm.js": {
-    "bundled": 52849,
-    "minified": 23149,
-    "gzipped": 6465,
+    "bundled": 53890,
+    "minified": 23746,
+    "gzipped": 6561,
     "treeshaked": {
       "rollup": {
-        "code": 16262,
+        "code": 16665,
         "import_statements": 354
       },
       "webpack": {
-        "code": 17561
+        "code": 17966
       }
     }
   },
-  "dist/downshift.native.cjs.js": {
-    "bundled": 81756,
-    "minified": 32873,
-    "gzipped": 9728
-  },
-  "preact/dist/downshift.umd.js": {
-    "bundled": 77156,
-    "minified": 27099,
-    "gzipped": 8425
+  "preact/dist/downshift.esm.js": {
+    "bundled": 52479,
+    "minified": 22611,
+    "gzipped": 6366,
+    "treeshaked": {
+      "rollup": {
+        "code": 16655,
+        "import_statements": 336
+      },
+      "webpack": {
+        "code": 17921
+      }
+    }
   }
 }

--- a/cypress/integration/combobox.js
+++ b/cypress/integration/combobox.js
@@ -19,13 +19,13 @@ describe('combobox', () => {
       .should('have.value', 'Green')
   })
 
-  it('can up arrow to select last item', () => {
+  it('can arrow up to select last item', () => {
     cy.getByTestId('combobox-input')
       .type('{uparrow}{enter}') // open menu, last option is focused
       .should('have.value', 'Purple')
   })
 
-  it('can up arrow down select first item', () => {
+  it('can arrow down to select first item', () => {
     cy.getByTestId('combobox-input')
       .type('{downarrow}{enter}') // open menu, first option is focused
       .should('have.value', 'Black')
@@ -36,6 +36,20 @@ describe('combobox', () => {
       .type('{downarrow}{downarrow}{enter}') // open and select second item
       .should('have.value', 'Red')
   })
+
+  /* should be enabled if https://github.com/cypress-io/cypress/pull/3071 gets released.
+  it('can use home arrow to select first item', () => {
+    cy.getByTestId('combobox-input')
+      .type('{downarrow}{downarrow}{home}{enter}') // open to first, go down to second, return to first by home.
+      .should('have.value', 'Black')
+  })
+
+  it('can use end arrow to select last item', () => {
+    cy.getByTestId('combobox-input')
+      .type('{downarrow}{end}{enter}') // open to first, go to last by end.
+      .should('have.value', 'Purple')
+  })
+  */
 
   it('resets the item on blur', () => {
     cy.getByTestId('combobox-input')

--- a/src/__tests__/downshift.get-input-props.js
+++ b/src/__tests__/downshift.get-input-props.js
@@ -18,7 +18,7 @@ const colors = [
 ]
 
 test('manages arrow up and down behavior', () => {
-  const {arrowUpInput, arrowDownInput, childrenSpy} = renderDownshift()
+  const {arrowUpInput, arrowDownInput, childrenSpy, endOnInput, homeOnInput} = renderDownshift()
   // ↓
   arrowDownInput()
   expect(childrenSpy).toHaveBeenLastCalledWith(
@@ -69,6 +69,16 @@ test('manages arrow up and down behavior', () => {
 
   // ↓
   arrowDownInput()
+  expect(childrenSpy).toHaveBeenLastCalledWith(
+    expect.objectContaining({highlightedIndex: 0}),
+  )
+
+  endOnInput()
+  expect(childrenSpy).toHaveBeenLastCalledWith(
+    expect.objectContaining({highlightedIndex: colors.length - 1}),
+  )
+
+  homeOnInput()
   expect(childrenSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({highlightedIndex: 0}),
   )
@@ -407,10 +417,14 @@ function renderDownshift({items, props} = {}) {
       fireEvent.keyDown(input, {key: 'ArrowDown', ...extraEventProps}),
     arrowUpInput: extraEventProps =>
       fireEvent.keyDown(input, {key: 'ArrowUp', ...extraEventProps}),
+    endOnInput: extraEventProps =>
+      fireEvent.keyDown(input, {key: 'End', ...extraEventProps}),
     escapeOnInput: extraEventProps =>
       fireEvent.keyDown(input, {key: 'Escape', ...extraEventProps}),
     enterOnInput: extraEventProps =>
       fireEvent.keyDown(input, {key: 'Enter', ...extraEventProps}),
+    homeOnInput: extraEventProps =>
+      fireEvent.keyDown(input, {key: 'Home', ...extraEventProps}),
     changeInputValue: (value, extraEventProps) =>
       fireEvent.change(input, {target: {value}, ...extraEventProps}),
     blurOnInput: extraEventProps => fireEvent.blur(input, extraEventProps),

--- a/src/__tests__/downshift.get-input-props.js
+++ b/src/__tests__/downshift.get-input-props.js
@@ -84,11 +84,26 @@ test('manages arrow up and down behavior', () => {
   )
 })
 
-test('arrow key down events do nothing when no items are rendered', () => {
-  const {arrowDownInput, childrenSpy} = renderDownshift({items: []})
-  // ↓↓
+test('navigation key down events do nothing when no items are rendered', () => {
+  const {arrowDownInput, arrowUpInput, endOnInput, homeOnInput, childrenSpy} = renderDownshift({items: []})
+  // ↓ ↓ ↑ end home
+  arrowDownInput() // open dropdown, nothing highlighted if no options
+  expect(childrenSpy).toHaveBeenLastCalledWith(
+    expect.objectContaining({highlightedIndex: null}),
+  )
   arrowDownInput()
-  arrowDownInput()
+  expect(childrenSpy).toHaveBeenLastCalledWith(
+    expect.objectContaining({highlightedIndex: null}),
+  )
+  arrowUpInput()
+  expect(childrenSpy).toHaveBeenLastCalledWith(
+    expect.objectContaining({highlightedIndex: null}),
+  )
+  endOnInput()
+  expect(childrenSpy).toHaveBeenLastCalledWith(
+    expect.objectContaining({highlightedIndex: null}),
+  )
+  homeOnInput()
   expect(childrenSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({highlightedIndex: null}),
   )

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -301,6 +301,21 @@ class Downshift extends Component {
     this.setHighlightedIndex(newIndex, otherStateToSet)
   }
 
+  highlightFirstIndex(otherStateToSet) {
+    if (this.getItemCount() === 0) {
+      return
+    }
+    this.setHighlightedIndex(0, otherStateToSet)
+  }
+
+  highlightLastIndex(otherStateToSet) {
+    const itemsLastIndex = this.getItemCount() - 1
+    if (itemsLastIndex < 0) {
+      return
+    }
+    this.setHighlightedIndex(itemsLastIndex, otherStateToSet)
+  }
+
   clearSelection = cb => {
     this.internalSetState(
       {
@@ -568,6 +583,18 @@ class Downshift extends Component {
       this.moveHighlightedIndex(amount, {
         type: stateChangeTypes.keyDownArrowUp,
       })
+    },
+
+    Home(event) {
+      event.preventDefault()
+      event.stopPropagation()
+      this.highlightFirstIndex({ type: stateChangeTypes.keyDownHome})
+    },
+
+    End(event) {
+      event.preventDefault()
+      event.stopPropagation()
+      this.highlightLastIndex({ type: stateChangeTypes.keyDownEnd})
     },
 
     Enter(event) {

--- a/src/stateChangeTypes.js
+++ b/src/stateChangeTypes.js
@@ -11,6 +11,8 @@ export const keyDownArrowDown = productionEnum(
 )
 export const keyDownEscape = productionEnum('__autocomplete_keydown_escape__')
 export const keyDownEnter = productionEnum('__autocomplete_keydown_enter__')
+export const keyDownHome = productionEnum('__autocomplete_keydown_home__')
+export const keyDownEnd = productionEnum('__autocomplete_keydown_enter__')
 export const clickItem = productionEnum('__autocomplete_click_item__')
 export const blurInput = productionEnum('__autocomplete_blur_input__')
 export const changeInput = productionEnum('__autocomplete_change_input__')


### PR DESCRIPTION
**What**:
This PR aims to improve kb navigation inside the listbox by adding support for `Home` and `End`. These keys should highlight first / last element, if the listbox is visible.

**Why**:
Improves the component by adding another ARIA specification regarding kb navigation.

**How**:
Added event listeners for keydown on both `Home` and `End`, and added handlers for each, in which I've used variations for the `setHighlightedIndex` function. Also added event names for both kets.

Also added UTs for these changes, and planning to add E2E Cypress tests too. These are already written, however Cypress does not support Home and End at the moment. I've created a PR for implementing this in their repo [here](https://github.com/cypress-io/cypress/pull/3071). Those tests are currently commented.

**Checklist**:

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->
