### PR TITLE
Revert "fix(events): stop handled key events propagating (#633)"

### DIFF
--- a/src/__tests__/downshift.get-button-props.js
+++ b/src/__tests__/downshift.get-button-props.js
@@ -90,26 +90,6 @@ test(`getToggleButtonProps doesn't include event handlers when disabled is passe
   }
 })
 
-test('stops key events that downshift has handled from propagating', () => {
-  const keyDownSpy = jest.fn()
-  const {container} = render(
-    <div onKeyDown={keyDownSpy}>
-      <Downshift isOpen highlightedIndex={1}>
-        {({getToggleButtonProps}) => <button {...getToggleButtonProps()} />}
-      </Downshift>
-    </div>,
-  )
-
-  const button = container.querySelector('button')
-
-  fireEvent.keyDown(button, {key: 'ArrowDown'})
-  fireEvent.keyDown(button, {key: 'ArrowUp'})
-  fireEvent.keyDown(button, {key: 'Enter'})
-  fireEvent.keyDown(button, {key: 'Escape'})
-
-  expect(keyDownSpy).toHaveBeenCalledTimes(0)
-})
-
 describe('Expect timer to trigger on process.env.NODE_ENV !== test value', () => {
   const originalEnv = process.env.NODE_ENV
 

--- a/src/__tests__/downshift.get-input-props.js
+++ b/src/__tests__/downshift.get-input-props.js
@@ -342,26 +342,6 @@ test(`getInputProps doesn't include event handlers when disabled is passed (for 
   }
 })
 
-test('stops events that downshift has handled from propagating', () => {
-  const keyDownSpy = jest.fn()
-  const {container} = render(
-    <div onKeyDown={keyDownSpy}>
-      <Downshift isOpen highlightedIndex={1}>
-        {({getInputProps}) => <input {...getInputProps()} />}
-      </Downshift>
-    </div>,
-  )
-
-  const input = container.querySelector('input')
-
-  fireEvent.keyDown(input, {key: 'ArrowDown'})
-  fireEvent.keyDown(input, {key: 'ArrowUp'})
-  fireEvent.keyDown(input, {key: 'Enter'})
-  fireEvent.keyDown(input, {key: 'Escape'})
-
-  expect(keyDownSpy).toHaveBeenCalledTimes(0)
-})
-
 function setupDownshiftWithState() {
   const items = ['animal', 'bug', 'cat']
   const utils = renderDownshift({items})

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -585,14 +585,12 @@ class Downshift extends Component {
 
     Home(event) {
       event.preventDefault()
-      event.stopPropagation()
-      this.highlightFirstIndex({ type: stateChangeTypes.keyDownHome})
+      this.highlightFirstIndex({type: stateChangeTypes.keyDownHome})
     },
 
     End(event) {
       event.preventDefault()
-      event.stopPropagation()
-      this.highlightLastIndex({ type: stateChangeTypes.keyDownEnd})
+      this.highlightLastIndex({type: stateChangeTypes.keyDownEnd})
     },
 
     Enter(event) {

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -569,7 +569,6 @@ class Downshift extends Component {
   keyDownHandlers = {
     ArrowDown(event) {
       event.preventDefault()
-      event.stopPropagation()
       const amount = event.shiftKey ? 5 : 1
       this.moveHighlightedIndex(amount, {
         type: stateChangeTypes.keyDownArrowDown,
@@ -578,7 +577,6 @@ class Downshift extends Component {
 
     ArrowUp(event) {
       event.preventDefault()
-      event.stopPropagation()
       const amount = event.shiftKey ? -5 : -1
       this.moveHighlightedIndex(amount, {
         type: stateChangeTypes.keyDownArrowUp,
@@ -601,7 +599,6 @@ class Downshift extends Component {
       const {isOpen, highlightedIndex} = this.getState()
       if (isOpen && highlightedIndex != null) {
         event.preventDefault()
-        event.stopPropagation()
         const item = this.items[highlightedIndex]
         const itemNode = this.getItemNodeFromIndex(highlightedIndex)
         if (item == null || (itemNode && itemNode.hasAttribute('disabled'))) {
@@ -615,7 +612,6 @@ class Downshift extends Component {
 
     Escape(event) {
       event.preventDefault()
-      event.stopPropagation()
       this.reset({type: stateChangeTypes.keyDownEscape})
     },
   }


### PR DESCRIPTION
This reverts commit 5084cd05d0ca5ef7ff9f95de5a8dab9e882d73d8.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What** and **Why**

The changes as part of #633 were incomplete, did not provide a way to allow downshift to handle event and optionally stop propagation, and incorrectly always stopped event propagation on Escape Keydown events.

See discussion in #642 and #643

Whilst we may want to do some stopping of propagation, for now this just reverts that PR so that the events are always propagated.



