### PR TITLE
Fix issue #651

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,59 +1,59 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 54264,
-    "minified": 24037,
-    "gzipped": 6628
+    "bundled": 54407,
+    "minified": 24135,
+    "gzipped": 6681
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 52833,
-    "minified": 22887,
-    "gzipped": 6433
+    "bundled": 52976,
+    "minified": 22985,
+    "gzipped": 6485
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 63298,
-    "minified": 22029,
-    "gzipped": 7062
+    "bundled": 64448,
+    "minified": 22075,
+    "gzipped": 7093
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 67475,
-    "minified": 23203,
-    "gzipped": 7603
+    "bundled": 68904,
+    "minified": 23249,
+    "gzipped": 7636
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 75473,
-    "minified": 27153,
-    "gzipped": 8435
+    "bundled": 76663,
+    "minified": 27158,
+    "gzipped": 8429
   },
   "dist/downshift.umd.js": {
-    "bundled": 104362,
-    "minified": 35748,
-    "gzipped": 11020
+    "bundled": 104737,
+    "minified": 35663,
+    "gzipped": 11027
   },
   "dist/downshift.esm.js": {
-    "bundled": 53890,
-    "minified": 23746,
-    "gzipped": 6561,
+    "bundled": 54033,
+    "minified": 23844,
+    "gzipped": 6612,
     "treeshaked": {
       "rollup": {
-        "code": 16665,
+        "code": 16714,
         "import_statements": 354
       },
       "webpack": {
-        "code": 17966
+        "code": 18013
       }
     }
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 52479,
-    "minified": 22611,
-    "gzipped": 6366,
+    "bundled": 52622,
+    "minified": 22709,
+    "gzipped": 6416,
     "treeshaked": {
       "rollup": {
-        "code": 16655,
+        "code": 16704,
         "import_statements": 336
       },
       "webpack": {
-        "code": 17921
+        "code": 17968
       }
     }
   }

--- a/src/__tests__/downshift.get-input-props.js
+++ b/src/__tests__/downshift.get-input-props.js
@@ -18,7 +18,13 @@ const colors = [
 ]
 
 test('manages arrow up and down behavior', () => {
-  const {arrowUpInput, arrowDownInput, childrenSpy, endOnInput, homeOnInput} = renderDownshift()
+  const {
+    arrowUpInput,
+    arrowDownInput,
+    childrenSpy,
+    endOnInput,
+    homeOnInput,
+  } = renderDownshift()
   // ↓
   arrowDownInput()
   expect(childrenSpy).toHaveBeenLastCalledWith(
@@ -84,32 +90,16 @@ test('manages arrow up and down behavior', () => {
   )
 })
 
-test('navigation key down events do nothing when no items are rendered', () => {
-  const {arrowDownInput, arrowUpInput, endOnInput, homeOnInput, childrenSpy} = renderDownshift({items: []})
-  // ↓ ↓ ↑ end home
-  arrowDownInput() // open dropdown, nothing highlighted if no options
-  expect(childrenSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({highlightedIndex: null}),
-  )
+test('arrow down opens menu and highlights first item by default', () => {
+  const {arrowDownInput, childrenSpy} = renderDownshift()
+  // ↓
   arrowDownInput()
   expect(childrenSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({highlightedIndex: null}),
-  )
-  arrowUpInput()
-  expect(childrenSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({highlightedIndex: null}),
-  )
-  endOnInput()
-  expect(childrenSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({highlightedIndex: null}),
-  )
-  homeOnInput()
-  expect(childrenSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({highlightedIndex: null}),
+    expect.objectContaining({isOpen: true, highlightedIndex: 0}),
   )
 })
 
-test('arrow up on a closed menu opens the menu and highlights last option', () => {
+test('arrow up opens menu and highlights last item by default', () => {
   const {arrowUpInput, childrenSpy} = renderDownshift()
   // ↑
   arrowUpInput()
@@ -119,12 +109,54 @@ test('arrow up on a closed menu opens the menu and highlights last option', () =
       highlightedIndex: colors.length - 1,
     }),
   )
+})
 
+test('arrow down opens menu and highlights defaultHighlightedIndex + 1 if provided', () => {
+  const defaultHighlightedIndex = 2
+  const {arrowDownInput, childrenSpy} = renderDownshift({
+    props: {defaultHighlightedIndex},
+  })
+  // ↓
+  arrowDownInput()
+  expect(childrenSpy).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      isOpen: true,
+      highlightedIndex: defaultHighlightedIndex + 1,
+    }),
+  )
+})
+
+test('arrow up opens menu and highlights defaultHighlightedIndex - 1 if provided', () => {
+  const defaultHighlightedIndex = 2
+  const {arrowUpInput, childrenSpy} = renderDownshift({
+    props: {defaultHighlightedIndex},
+  })
   // ↑
   arrowUpInput()
   expect(childrenSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({highlightedIndex: colors.length - 2}),
+    expect.objectContaining({
+      isOpen: true,
+      highlightedIndex: defaultHighlightedIndex - 1,
+    }),
   )
+})
+
+test('navigation key down events do nothing when no items are rendered', () => {
+  const {
+    arrowDownInput,
+    arrowUpInput,
+    endOnInput,
+    homeOnInput,
+    childrenSpy,
+  } = renderDownshift({items: []})
+  const keysOnInput = [arrowDownInput, arrowUpInput, endOnInput, homeOnInput]
+  // ↓ ↑ end home
+  keysOnInput.forEach(keyOnInput => {
+    keyOnInput()
+    expect(childrenSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({highlightedIndex: null}),
+    )
+  })
 })
 
 test('enter on an input with a closed menu does nothing', () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -264,6 +264,28 @@ function isPlainObject(obj) {
   return Object.prototype.toString.call(obj) === '[object Object]'
 }
 
+/**
+ * Returns the new index in the list, in a circular way.
+ * @param {number} moveAmount Number of positions to move. Negative to move backwards, positive forwards.
+ * @param {number} baseIndex The initial position to move from.
+ * @param {number} itemCount The total number of items.
+ * @returns {number} The new index after the move.
+ */
+function computeNewIndex(moveAmount, baseIndex, itemCount) {
+  const itemsLastIndex = itemCount - 1
+
+  if (baseIndex === null) {
+    baseIndex = moveAmount > 0 ? -1 : itemsLastIndex + 1
+  }
+  let newIndex = baseIndex + moveAmount
+  if (newIndex < 0) {
+    newIndex = itemsLastIndex
+  } else if (newIndex > itemsLastIndex) {
+    newIndex = 0
+  }
+  return newIndex
+}
+
 export {
   cbToCb,
   callAllEventHandlers,
@@ -283,4 +305,5 @@ export {
   pickState,
   isPlainObject,
   normalizeArrowKey,
+  computeNewIndex,
 }


### PR DESCRIPTION
Addresses https://github.com/paypal/downshift/issues/651.

If there is a `defaultHighlightedIndex' prop given to Downshift, then that index will be highlighted when user will open the dropdown with click, enter and space. When dropdown is open with Up/Down Arrows, the highlighted index will be `defaultHighlightedIndex'  -/+ 1.

If there is no `defaultHighlightedIndex' given as prop, default will remain as it is now: Up/Down will highlight last/first option, while click, enter and space will not highlight anything.